### PR TITLE
change required react peer dependecy version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@consumidor-positivo/aurora",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@consumidor-positivo/aurora",
-      "version": "0.0.32",
+      "version": "0.0.33",
       "dependencies": {
         "@fontsource-variable/lexend-deca": "5.0.13",
         "@fontsource-variable/source-sans-3": "5.0.21",
@@ -57,8 +57,8 @@
         "vite-plugin-static-copy": "1.0.6"
       },
       "peerDependencies": {
-        "react": ">=18.3.1",
-        "react-dom": ">=18.3.1"
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@consumidor-positivo/aurora",
   "private": false,
-  "version": "0.0.32",
+  "version": "0.0.33",
   "type": "module",
   "main": "./dist/main.es.js",
   "modules": "./dist/main.es.js",
@@ -36,8 +36,8 @@
     "prepare": "husky"
   },
   "peerDependencies": {
-    "react": ">=18.3.1",
-    "react-dom": ">=18.3.1"
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "dependencies": {
     "@fontsource-variable/lexend-deca": "5.0.13",


### PR DESCRIPTION
The installation process is failing on some consumer projects due to peer dependencies incompatibility.