### PR TITLE
fix: remove footer extra padding, unused gap

### DIFF
--- a/lib/components/Footer/styles.scss
+++ b/lib/components/Footer/styles.scss
@@ -1,10 +1,10 @@
 .au-footer {
   background-color: $color-neutral-00;
   border-top: 1px solid $color-neutral-20;
-  padding: $spacing-600 0;
+  padding-block: $spacing-600;
 
   @include aboveLarge() {
-    padding: $spacing-800;
+    padding-block: $spacing-800;
   }
 
   &__container {
@@ -136,10 +136,10 @@
 .au-footer-full {
   background-color: $color-neutral-00;
   border-top: 1px solid $color-neutral-20;
-  padding: $spacing-600 0;
-  gap: $spacing-600;
+  padding-block: $spacing-600;
+
   @include aboveLarge() {
-    padding: $spacing-800;
+    padding-block: $spacing-800;
   }
 
   &__container {


### PR DESCRIPTION
Neste PR estou fazendo a remoção do padding desnecessário nas laterais do footer para desktop, como foi adicionado o container no PR passado, não precisamos mais desse espaçamento e está causando desalinhamento com o container do header nos projetos da área aberta e do app em dimensões que são menores que 1440px.