### PR TITLE
Input de senha

### DIFF
--- a/lib/components/form/Field/styles.scss
+++ b/lib/components/form/Field/styles.scss
@@ -83,8 +83,7 @@
       border-color: $color-error-50;
 
       &:focus {
-        border-color: $color-error-50;
-        outline: 1px solid $color-error-50;
+        border-color: $color-brand-blue-40;
       }
     }
 

--- a/lib/components/form/InputField/InputField.stories.tsx
+++ b/lib/components/form/InputField/InputField.stories.tsx
@@ -28,8 +28,8 @@ export const Focus: Story = {
   args: {
     id: 'focus-input',
     autoFocus: true,
-    ...commonArgs
-  }
+    ...commonArgs,
+  },
 }
 
 export const Required: Story = {
@@ -55,6 +55,13 @@ export const Success: Story = {
     success: true,
     ...commonArgs,
   },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Estilo temporário com duração de 2 segundos',
+      },
+    },
+  },
 }
 
 export const Error: Story = {
@@ -77,6 +84,6 @@ export const Disabled: Story = {
 export const WithoutLabel: Story = {
   args: {
     style: commonArgs.style,
-    placeholder: commonArgs.placeholder
+    placeholder: commonArgs.placeholder,
   },
 }

--- a/lib/components/form/PasswordField/PasswordField.stories.tsx
+++ b/lib/components/form/PasswordField/PasswordField.stories.tsx
@@ -1,0 +1,82 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { PasswordField } from './index'
+
+const meta: Meta<typeof PasswordField> = {
+  title: 'Components/form/PasswordField',
+  component: PasswordField,
+  tags: ['autodocs'],
+}
+
+export default meta
+
+type Story = StoryObj<typeof PasswordField>
+
+const commonArgs = {
+  label: 'Digite sua senha',
+  placeholder: 'Text',
+  style: { maxWidth: '272px' },
+}
+
+export const Default: Story = {
+  args: {
+    id: 'default-input',
+    ...commonArgs,
+  },
+}
+
+export const Focus: Story = {
+  args: {
+    id: 'focus-input',
+    autoFocus: true,
+    ...commonArgs
+  }
+}
+
+export const Required: Story = {
+  args: {
+    id: 'required-input',
+    requiredInput: true,
+    required: true,
+    ...commonArgs,
+  },
+}
+
+export const Optional: Story = {
+  args: {
+    id: 'optional-input',
+    optional: true,
+    ...commonArgs,
+  },
+}
+
+export const Success: Story = {
+  args: {
+    id: 'success-input',
+    success: true,
+    ...commonArgs,
+  },
+}
+
+export const Error: Story = {
+  args: {
+    id: 'error-input',
+    error: true,
+    errorMessage: 'Senha incorreta',
+    ...commonArgs,
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    id: 'disabled-input',
+    disabled: true,
+    ...commonArgs,
+  },
+}
+
+export const WithoutLabel: Story = {
+  args: {
+    style: commonArgs.style,
+    placeholder: commonArgs.placeholder
+  },
+}

--- a/lib/components/form/PasswordField/PasswordField.stories.tsx
+++ b/lib/components/form/PasswordField/PasswordField.stories.tsx
@@ -28,8 +28,8 @@ export const Focus: Story = {
   args: {
     id: 'focus-input',
     autoFocus: true,
-    ...commonArgs
-  }
+    ...commonArgs,
+  },
 }
 
 export const Required: Story = {
@@ -55,6 +55,13 @@ export const Success: Story = {
     success: true,
     ...commonArgs,
   },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Estilo temporário com duração de 2 segundos',
+      },
+    },
+  },
 }
 
 export const Error: Story = {
@@ -77,6 +84,6 @@ export const Disabled: Story = {
 export const WithoutLabel: Story = {
   args: {
     style: commonArgs.style,
-    placeholder: commonArgs.placeholder
+    placeholder: commonArgs.placeholder,
   },
 }

--- a/lib/components/form/PasswordField/hook.tsx
+++ b/lib/components/form/PasswordField/hook.tsx
@@ -1,0 +1,17 @@
+import { useState } from 'react'
+
+export const usePasswordField = () => {
+  const [showPassword, setShowPassword] = useState<boolean>(false)
+  const fieldType = showPassword ? 'text' : 'password'
+  const textButton = showPassword ? 'ocultar' : 'mostrar'
+
+  function changeVisibility() {
+    setShowPassword((prevState) => !prevState)
+  }
+
+  return {
+    fieldType,
+    textButton,
+    changeVisibility,
+  }
+}

--- a/lib/components/form/PasswordField/index.tsx
+++ b/lib/components/form/PasswordField/index.tsx
@@ -1,0 +1,64 @@
+import Field from '../Field'
+import { usePasswordField } from './hook'
+import './styles.scss'
+
+type PasswordFieldProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  type?: 'password'
+  optional?: boolean
+  requiredInput?: boolean
+  success?: boolean
+  error?: boolean
+  errorMessage?: string
+  label?: string
+  ref?: React.RefObject<HTMLInputElement>
+}
+
+export const PasswordField = ({
+  optional,
+  requiredInput,
+  success,
+  error,
+  errorMessage,
+  label,
+  ref,
+  id,
+  disabled,
+  style,
+  className,
+  ...props
+}: PasswordFieldProps) => {
+  const { fieldType, textButton, changeVisibility } = usePasswordField()
+
+  return (
+    <Field.Root
+      style={style}
+      customclass={className}
+      success={success}
+      error={error}
+      disabled={disabled}>
+      <Field.Label
+        text={label}
+        id={id}
+        required={requiredInput}
+        optional={optional}
+        success={success}
+        error={error}
+        disabled={disabled}
+      />
+      <div className="au-password-field__container">
+        <Field.Input
+          customclass="au-password-field__input"
+          type={fieldType}
+          id={id}
+          ref={ref}
+          disabled={disabled}
+          {...props}
+        />
+        <button className="au-password-field__btn" onClick={changeVisibility}>
+          {textButton}
+        </button>
+      </div>
+      <Field.ErrorMessage hasError={!!error} message={errorMessage} />
+    </Field.Root>
+  )
+}

--- a/lib/components/form/PasswordField/styles.scss
+++ b/lib/components/form/PasswordField/styles.scss
@@ -6,6 +6,7 @@
 
     &__input {
         position: absolute;
+        padding: 16px 94px 16px 16px;
     }
 
     &__btn {

--- a/lib/components/form/PasswordField/styles.scss
+++ b/lib/components/form/PasswordField/styles.scss
@@ -1,0 +1,25 @@
+.au-password-field {
+    &__container {
+        position: relative;
+        height: 56px;
+    }
+
+    &__input {
+        position: absolute;
+    }
+
+    &__btn {
+        background-color: transparent;
+        border: none;
+        color: $color-brand-blue-40;
+        cursor: pointer;
+        font-size: 14px;
+        font-weight: 600;
+        text-transform: uppercase;
+        position: absolute;
+        z-index: 1;
+        background-position-y: center;
+        right: 16px;
+        height: 56px;
+    }
+}

--- a/lib/components/form/TokenField/TokenField.stories.tsx
+++ b/lib/components/form/TokenField/TokenField.stories.tsx
@@ -18,21 +18,28 @@ const commonArgs = {
 
 export const Default: Story = {
   args: {
-    ...commonArgs
+    ...commonArgs,
   },
 }
 
 export const CustomSize: Story = {
   args: {
     size: 4,
-    ...commonArgs
-  }
+    ...commonArgs,
+  },
 }
 
 export const Success: Story = {
   args: {
     success: true,
     ...commonArgs,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Estilo temporário com duração de 2 segundos',
+      },
+    },
   },
 }
 

--- a/lib/components/form/TokenField/hook.tsx
+++ b/lib/components/form/TokenField/hook.tsx
@@ -14,13 +14,13 @@ function inputtedValueIsValid(value: unknown) {
   return !isNaN
 }
 
-export default function useTokenField({
+export const useTokenField = ({
   size,
   onComplete,
   onChange,
   onChangeTimer,
   timer = null,
-}: UseTokenInputProps) {
+}: UseTokenInputProps) => {
   const rootElementRef = useRef<HTMLDivElement | null>(null)
   const [tokenMap, setTokenMap] = useState(_getDefaultTokens())
   const [timerTime, setTimerTime] = useState<number | null>(timer)
@@ -56,7 +56,7 @@ export default function useTokenField({
           }
         })
       }, 1000)
-      
+
       if (interval) {
         return () => clearInterval(interval)
       }

--- a/lib/components/form/TokenField/index.tsx
+++ b/lib/components/form/TokenField/index.tsx
@@ -1,5 +1,5 @@
 import Field from '../Field'
-import useTokenField from './hook'
+import { useTokenField } from './hook'
 import './styles.scss'
 
 type TokenFieldProps = {
@@ -31,8 +31,13 @@ export const TokenField = ({
   onComplete,
   onChange,
 }: TokenFieldProps) => {
-  const { tokenMap, rootElementRef, onChangeNumber, onKeyUpHandler, onPasteNumber } =
-    useTokenField({ size, onComplete, onChange, onChangeTimer, timer })
+  const {
+    tokenMap,
+    rootElementRef,
+    onChangeNumber,
+    onKeyUpHandler,
+    onPasteNumber,
+  } = useTokenField({ size, onComplete, onChange, onChangeTimer, timer })
 
   return (
     <Field.Root

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -14,6 +14,7 @@ export { Text } from './components/Text'
 export { Footer } from './components/Footer'
 export { InputField } from './components/form/InputField'
 export { TokenField } from './components/form/TokenField'
+export { PasswordField } from './components/form/PasswordField'
 
 // Hooks
 export { useDrawer } from './components/Drawer/hooks'


### PR DESCRIPTION
- add input de senha: `PasswordField`
![image](https://github.com/user-attachments/assets/bc378b72-c198-4660-a564-1693639e46f1)
![image](https://github.com/user-attachments/assets/d368df2b-d5e0-4dfe-9a15-65f932d288af)

- ajustar export/import do token field de acordo com o padrão

- add descritivo do status `success`  nas docs dos inputs 