### PR TITLE
feat(form): help text + adjustments on label

### DIFF
--- a/lib/components/form/Field/Label/index.tsx
+++ b/lib/components/form/Field/Label/index.tsx
@@ -9,25 +9,24 @@ type FieldLabelProps = {
   id?: string
   text?: string
   required?: boolean
-  optional?: boolean
   success?: boolean
   error?: boolean
   disabled?: boolean
+  showOptionalLabel?: boolean
 }
 
 export const FieldLabel = ({
   id,
   text,
   required,
-  optional,
   success,
   error,
   disabled,
+  showOptionalLabel = true,
 }: FieldLabelProps) => {
   if (!text) return null
 
   const states = [
-    { state: 'optional', value: !!optional, icon: <span>(Opcional)</span> },
     {
       state: 'success',
       value: !!success,
@@ -51,7 +50,10 @@ export const FieldLabel = ({
     <div className="au-field__header">
       <label htmlFor={id} className="au-field__header-label">
         {text}{' '}
-        {required && (
+        {showOptionalLabel && !required && (
+          <span className="au-field__header-label--optional">(Opcional)</span>
+        )}
+        {!showOptionalLabel && required && (
           <strong className="au-field__header-label--required">*</strong>
         )}
       </label>

--- a/lib/components/form/Field/Message/index.tsx
+++ b/lib/components/form/Field/Message/index.tsx
@@ -1,0 +1,17 @@
+type FieldMessageProps = {
+  hasError?: boolean
+  errorMessage?: string
+  helpMessage?: string
+}
+
+export const FieldMessage = ({ hasError, errorMessage, helpMessage }: FieldMessageProps) => {
+  if (hasError && errorMessage) {
+    return <p className="au-field__message au-field__message--error">{errorMessage}</p>
+  }
+
+  if (helpMessage) {
+    return <p className="au-field__message">{helpMessage}</p>
+  }
+
+  return null
+}

--- a/lib/components/form/Field/index.tsx
+++ b/lib/components/form/Field/index.tsx
@@ -1,4 +1,5 @@
 import { FieldErrorMessage } from './ErrorMessage'
+import { FieldMessage } from './Message'
 import { FieldInput } from './Input'
 import { FieldInputHolder } from './InputHolder'
 import { FieldLabel } from './Label'
@@ -12,5 +13,6 @@ export default {
     InputHolder: FieldInputHolder,
     Label: FieldLabel,
     ErrorMessage: FieldErrorMessage,
+    Message: FieldMessage,
     TextArea: FieldTextArea,
 }

--- a/lib/components/form/Field/styles.scss
+++ b/lib/components/form/Field/styles.scss
@@ -81,6 +81,11 @@
       &--required {
         color: $color-error-50;
       }
+
+      &--optional {
+        color: $color-neutral-50;
+        font-weight: 400;
+      }
     }
 
     &-icon {
@@ -98,12 +103,16 @@
     transform: translateY(-50%);
   }
 
-  &__error-message {
-    color: $color-error-50;
-    font-size: 16px;
+  &__message {
+    font-size: 14px;
     font-weight: 400;
-    line-height: 24px;
+    line-height: 22px;
     padding-top: 8px;
+    color: $color-neutral-50;
+
+    &--error {
+      color: $color-error-50;
+    }
   }
 
   &--disabled {

--- a/lib/components/form/InputField/InputField.stories.tsx
+++ b/lib/components/form/InputField/InputField.stories.tsx
@@ -38,19 +38,18 @@ export const Focus: Story = {
   },
 }
 
-export const Required: Story = {
+export const HelpText: Story = {
   args: {
-    id: 'required-input',
-    requiredInput: true,
-    required: true,
+    id: 'help-text-input',
+    helpMessage: 'Help text',
     ...commonArgs,
   },
 }
-
-export const Optional: Story = {
+export const ShowRequired: Story = {
   args: {
-    id: 'optional-input',
-    optional: true,
+    id: 'show-required-input',
+    requiredInput: true,
+    showOptionalLabel: false,
     ...commonArgs,
   },
 }
@@ -91,5 +90,13 @@ export const WithoutLabel: Story = {
   args: {
     style: commonArgs.style,
     placeholder: commonArgs.placeholder,
+  },
+}
+
+export const HelperMessage: Story = {
+  args: {
+    id: 'helper-input',
+    helpMessage: 'Help text',
+    ...commonArgs,
   },
 }

--- a/lib/components/form/InputField/index.tsx
+++ b/lib/components/form/InputField/index.tsx
@@ -1,11 +1,12 @@
 import Field from '../Field'
 
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
-  optional?: boolean
+  showOptionalLabel?: boolean
   requiredInput?: boolean
   success?: boolean
   error?: boolean
   errorMessage?: string
+  helpMessage?: string
   rightSlot?: React.ReactNode
   label?: string
   inputStyle?: React.CSSProperties
@@ -13,11 +14,12 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
 }
 
 export const InputField = ({
-  optional,
+  showOptionalLabel,
   requiredInput,
   success,
   error,
   errorMessage,
+  helpMessage,
   label,
   id,
   disabled,
@@ -39,8 +41,8 @@ export const InputField = ({
       <Field.Label
         text={label}
         id={id}
+        showOptionalLabel={showOptionalLabel}
         required={requiredInput}
-        optional={optional}
         success={success}
         error={error}
         disabled={disabled}
@@ -54,7 +56,7 @@ export const InputField = ({
           {...props}
         />
       </Field.InputHolder>
-      <Field.ErrorMessage hasError={!!error} message={errorMessage} />
+      <Field.Message hasError={!!error} errorMessage={errorMessage} helpMessage={helpMessage} />
     </Field.Root>
   )
 }

--- a/lib/components/form/PasswordField/PasswordField.stories.tsx
+++ b/lib/components/form/PasswordField/PasswordField.stories.tsx
@@ -47,13 +47,6 @@ export const Required: Story = {
   },
 }
 
-export const Optional: Story = {
-  args: {
-    id: 'optional-input',
-    optional: true,
-    ...commonArgs,
-  },
-}
 
 export const Success: Story = {
   args: {

--- a/lib/components/form/PasswordField/index.tsx
+++ b/lib/components/form/PasswordField/index.tsx
@@ -4,7 +4,7 @@ import './styles.scss'
 
 type PasswordFieldProps = React.InputHTMLAttributes<HTMLInputElement> & {
   type?: 'password'
-  optional?: boolean
+  showOptionalLabel?: boolean
   requiredInput?: boolean
   success?: boolean
   error?: boolean
@@ -14,7 +14,7 @@ type PasswordFieldProps = React.InputHTMLAttributes<HTMLInputElement> & {
 }
 
 export const PasswordField = ({
-  optional,
+  showOptionalLabel,
   requiredInput,
   success,
   error,
@@ -40,7 +40,7 @@ export const PasswordField = ({
         text={label}
         id={id}
         required={requiredInput}
-        optional={optional}
+        showOptionalLabel={showOptionalLabel}
         success={success}
         error={error}
         disabled={disabled}

--- a/lib/components/form/SelectField/SelectField.stories.tsx
+++ b/lib/components/form/SelectField/SelectField.stories.tsx
@@ -100,7 +100,7 @@ export const Optional: Story = {
   },
   args: {
     id: 'optional-select',
-    optional: true,
+    showOptionalLabel: true,
     ...commonArgs,
   },
 }

--- a/lib/components/form/SelectField/index.tsx
+++ b/lib/components/form/SelectField/index.tsx
@@ -8,9 +8,10 @@ import './styles.scss'
 export const SelectField = ({
   label,
   options,
-  optional,
+  showOptionalLabel,
   error,
   errorMessage,
+  helpMessage,
   disabled,
   required,
   value,
@@ -57,7 +58,7 @@ export const SelectField = ({
       disabled={disabled}>
       <Field.Label
         text={label}
-        optional={optional}
+        showOptionalLabel={showOptionalLabel}
         required={required}
         error={error}
         disabled={disabled}
@@ -146,7 +147,9 @@ export const SelectField = ({
           ))}
         </select>
       </div>
-      <Field.ErrorMessage hasError={!!error} message={errorMessage} />
+      <Field.Message hasError={!!error} errorMessage={errorMessage} helpMessage={helpMessage} />
+      
+      
     </Field.Root>
   )
 }

--- a/lib/components/form/SelectField/types.ts
+++ b/lib/components/form/SelectField/types.ts
@@ -7,11 +7,12 @@ export type OptionProps = {
 export type SelectFieldProps = React.HTMLAttributes<HTMLDivElement> & {
   label?: string
   options: OptionProps[]
-  optional?: boolean
+  showOptionalLabel?: boolean
   disabled?: boolean
   required?: boolean
   error?: boolean
   errorMessage?: string
+  helpMessage?: string
   placeholder?: string
   value?: string
   onChange?: (value: string) => void

--- a/lib/components/form/TextareaField/TexareaField.stories.tsx
+++ b/lib/components/form/TextareaField/TexareaField.stories.tsx
@@ -68,18 +68,11 @@ export const MoreRows: Story = {
   },
 }
 
-export const Required: Story = {
+export const ShowRequired: Story = {
   args: {
-    id: 'required-textarea',
+    id: 'show-required-textarea',
     required: true,
-    ...commonArgs,
-  },
-}
-
-export const Optional: Story = {
-  args: {
-    id: 'optional-textarea',
-    optional: true,
+    showOptionalLabel: false,
     ...commonArgs,
   },
 }

--- a/lib/components/form/TextareaField/index.tsx
+++ b/lib/components/form/TextareaField/index.tsx
@@ -2,10 +2,11 @@ import Field from '../Field'
 
 export type TextAreaProps =
   React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
-    optional?: boolean
+    showOptionalLabel?: boolean
     success?: boolean
     error?: boolean
     errorMessage?: string
+    helpMessage?: string
     label?: string
     textAreaStyle?: React.CSSProperties
     textareaRef?: React.RefObject<HTMLTextAreaElement>
@@ -13,11 +14,12 @@ export type TextAreaProps =
   }
 
 export const TextAreaField = ({
-  optional,
+  showOptionalLabel,
   required,
   success,
   error,
   errorMessage,
+  helpMessage,
   label,
   id,
   disabled,
@@ -40,7 +42,7 @@ export const TextAreaField = ({
         text={label}
         id={id}
         required={required}
-        optional={optional}
+        showOptionalLabel={showOptionalLabel}
         success={success}
         error={error}
         disabled={disabled}
@@ -54,7 +56,7 @@ export const TextAreaField = ({
         horizontalResize={horizontalResize}
         {...props}
       />
-      <Field.ErrorMessage hasError={!!error} message={errorMessage} />
+      <Field.Message hasError={!!error} errorMessage={errorMessage} helpMessage={helpMessage} />
     </Field.Root>
   )
 }

--- a/lib/components/form/TokenField/index.tsx
+++ b/lib/components/form/TokenField/index.tsx
@@ -8,6 +8,8 @@ type TokenFieldProps = {
   success?: boolean
   error?: boolean
   errorMessage?: string
+  helpMessage?: string
+  showOptionalLabel?: boolean
   size?: number
   type?: 'number' | 'password' | 'text'
   style?: React.CSSProperties
@@ -23,6 +25,8 @@ export const TokenField = ({
   success,
   error,
   errorMessage,
+  helpMessage,
+  showOptionalLabel,
   size = 6,
   type,
   style,
@@ -48,6 +52,7 @@ export const TokenField = ({
       disabled={disabled}>
       <Field.Label
         text={label}
+        showOptionalLabel={showOptionalLabel}
         success={success}
         error={error}
         disabled={disabled}
@@ -68,7 +73,7 @@ export const TokenField = ({
           </div>
         ))}
       </div>
-      <Field.ErrorMessage hasError={error} message={errorMessage} />
+      <Field.Message hasError={!!error} errorMessage={errorMessage} helpMessage={helpMessage} />
     </Field.Root>
   )
 }


### PR DESCRIPTION
- Adicionado help text (opcional)
- Os campos obrigatórios não mostram mais o *. Os opcionais agora mostram '(Opcional)' ao lado da label (Obs: opcional. (default true) -  Ainda é possível mostrar o * em campos required via props)
- Ajustes no tamanho da mensagem de erro.