### PR TITLE
chore: adjust spinner svg props

### DIFF
--- a/lib/components/Spinner/index.tsx
+++ b/lib/components/Spinner/index.tsx
@@ -22,11 +22,11 @@ export const Spinner: React.FC<SpinnerProps> = ({ size, color }) => {
             y1="0%"
             x2="90%"
             y2="10%">
-            <stop offset="0" stop-color={color} stop-opacity="1" />
-            <stop offset="1" stop-color={color} stop-opacity="0" />
+            <stop offset="0" stopColor={color} stopOpacity="1" />
+            <stop offset="1" stopColor={color} stopOpacity="0" />
           </linearGradient>
         </defs>
-        <g stroke-width="7" stroke-linecap="round" fill="none">
+        <g strokeWidth="7" strokeLinecap="round" fill="none">
           <path stroke={color} d="M60,32 A28,28 0 1 1 4,32" />
 
           <path


### PR DESCRIPTION
This pull request includes minor changes to the `Spinner` component in the `lib/components/Spinner/index.tsx` file. The changes correct the attribute names in the SVG elements to use camelCase instead of kebab-case.

* Corrected attribute names in SVG elements to use camelCase:
  * Changed `stop-color` to `stopColor` and `stop-opacity` to `stopOpacity`.
  * Changed `stroke-width` to `strokeWidth` and `stroke-linecap` to `strokeLinecap`.