### PR TITLE
fix: adjust spinner size

### DIFF
--- a/lib/components/Spinner/index.tsx
+++ b/lib/components/Spinner/index.tsx
@@ -7,7 +7,7 @@ type SpinnerProps = {
 
 export const Spinner: React.FC<SpinnerProps> = ({ size, color }) => {
   return (
-    <div className="au-spinner">
+    <div className="au-spinner" style={{ width: size, height: size }}>
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 64 64"


### PR DESCRIPTION
Adicionando largura e altura fixas com base no `size` passado para o spinner. A motivação desse ajuste é que a div ao redor fica maior do que o svg, ficando descentralizado com os textos quando implementado no projeto, por conta da sobra na altura.

**Hoje:**
![Screenshot 2025-04-24 at 10 49 18](https://github.com/user-attachments/assets/c76a5a50-2b88-46dd-ad9d-4db68424ef62)


**Após o ajuste:**
![Screenshot 2025-04-24 at 10 49 35](https://github.com/user-attachments/assets/72527057-2152-46c3-bc14-e6467f4f26fb)
