### PR TITLE
fix: 🐛 closing email domain suggestion

### DIFF
--- a/lib/components/form/EmailField/hook.ts
+++ b/lib/components/form/EmailField/hook.ts
@@ -25,16 +25,22 @@ export const useEmailAutocomplete = (propsOnChange?: (value: string) => void) =>
     setInputValue(value)
 		if(propsOnChange) propsOnChange(value);
 
-    const atIndex = value.indexOf('@')
+    const atIndex = value.indexOf('@');
+		let filteredDomains: string[] = [];
+
     if (atIndex > -1) {
       const domainPart = value.slice(atIndex + 1)
-      const filteredDomains = emailDomains.filter((domain) =>
+      filteredDomains = emailDomains.filter((domain) =>
         domain.startsWith(domainPart),
       )
       setSuggestions(filteredDomains)
       setIsDropdownOpen(filteredDomains.length > 0)
     } else {
       setSuggestions([])
+      setIsDropdownOpen(false)
+    }
+
+    if (filteredDomains.some(domain => value.endsWith(domain))) {
       setIsDropdownOpen(false)
     }
   }


### PR DESCRIPTION
* Closing the domain suggestion component when some value already exist in the value

before, typing or selectin a value from autofill does not close the suggestions. It was being closed only when the user select one option or type an email with a domain that does not exist on suggestion list

<img width="486" alt="image" src="https://github.com/user-attachments/assets/2a308710-21f1-4d1b-b00a-1b0170cfe99b" />

<img width="473" alt="image" src="https://github.com/user-attachments/assets/ee03e252-aca7-45d6-a923-92f95143eb72" />

