### PR TITLE
fix: display keyboard on select mobile

### DIFF
--- a/lib/components/form/SelectField/SelectField.stories.tsx
+++ b/lib/components/form/SelectField/SelectField.stories.tsx
@@ -55,6 +55,7 @@ export const FullScreenOptions: Story = {
   args: {
     id: 'fullscreen-select',
     fullScreenOptions: true,
+    autocomplete: true,
     ...commonArgs,
   },
 }

--- a/lib/components/form/SelectField/index.tsx
+++ b/lib/components/form/SelectField/index.tsx
@@ -37,6 +37,7 @@ export const SelectField = ({
   autocomplete = false,
   EmptyText = 'Nada encontrado',
   fullScreenOptions = false,
+  htmlType = 'text'
 }: SelectFieldProps) => {
   const {
     isDropdownOpen,
@@ -131,8 +132,9 @@ export const SelectField = ({
               value={searchValue || selectedOption.label}
               placeholder={placeholder || 'Selecionar...'}
               onChange={handleInputChange}
-              readOnly={!autocomplete}
+              readOnly={!autocomplete || (fullScreenOptions && isMobile())}
               disabled={disabled}
+              type={htmlType}
             />
             <div className="au-field__select-icon">
               <IconChevronDown />
@@ -236,6 +238,7 @@ export const SelectField = ({
                         placeholder={'Buscar'}
                         onChange={handleInputChange}
                         disabled={disabled}
+                        type={htmlType}
                       />
                       <div className="au-field__select-icon">
                         <IconSearch rawColor={COLOR_NEUTRAL_40} />

--- a/lib/components/form/SelectField/types.ts
+++ b/lib/components/form/SelectField/types.ts
@@ -21,4 +21,5 @@ export type SelectFieldProps = React.HTMLAttributes<HTMLDivElement> & {
   autocomplete?: boolean
   EmptyText?: string
   fullScreenOptions?: boolean
+  htmlType?: 'text' | 'number'
 }


### PR DESCRIPTION
- add htmlType prop no select
- manter o input readyOnly quando o select está em modo fullScreenOptions, para não subir o teclado no mobile junto com o modal.