### PR TITLE
feat: :sparkles: added notifications toggle to header profile component

### DIFF
--- a/lib/components/Header/parts/HeaderProfile.tsx
+++ b/lib/components/Header/parts/HeaderProfile.tsx
@@ -1,25 +1,33 @@
 import { getInitialLetters } from '@core/utils/getInitialLetters'
 import { IconBell, IconChevronDown, IconMenu } from '@components/icons/default'
+import { Conditional } from '@components/misc'
 
 export type HeaderProfileProps = {
   onClickNotifications?: () => void
   onClickMenu?: () => void
   fullName: string
+  showNotifications?: boolean
 }
 
 export const HeaderProfile = ({
   onClickNotifications,
   onClickMenu,
   fullName,
+  showNotifications = true,
 }: HeaderProfileProps) => {
   const initialLetters = getInitialLetters(fullName)
   return (
     <div className="au-header__profile">
-      <div
-        className="au-header__profile-notifications"
-        onClick={onClickNotifications}>
-        <IconBell />
-      </div>
+      <Conditional
+        condition={showNotifications}
+        renderIf={
+          <div
+            className="au-header__profile-notifications"
+            onClick={onClickNotifications}>
+            <IconBell />
+          </div>
+        }
+      />
 
       <div className="au-header__profile-menu-mobile" onClick={onClickMenu}>
         <IconMenu />


### PR DESCRIPTION
Conditionally rendering notifications icon on `Header.Profile` component.


<img width="196" alt="Captura de Tela 2025-06-26 às 17 52 58" src="https://github.com/user-attachments/assets/65e72b6a-0eb0-4789-b7fa-70233c6eda82" />
