### PR TITLE
feat: :sparkles: added badge expand property

### DIFF
--- a/lib/components/Header/parts/HeaderBadges.tsx
+++ b/lib/components/Header/parts/HeaderBadges.tsx
@@ -1,9 +1,17 @@
+import classNames from 'classnames'
 import { ReactNode } from 'react'
 
 export type HeaderBadgesProps = {
   children: ReactNode | string | JSX.Element | JSX.Element[]
+  limitBadgeWidth?: boolean
 }
 
-export const HeaderBadges = ({ children }: HeaderBadgesProps) => {
-  return <div className="au-header__badges">{children}</div>
+export const HeaderBadges = ({
+  children,
+  limitBadgeWidth = true,
+}: HeaderBadgesProps) => {
+  const componentClass = classNames('au-header__badges', {
+    'au-header__badges--limited-width': limitBadgeWidth,
+  })
+  return <div className={componentClass}>{children}</div>
 }

--- a/lib/components/Header/styles.scss
+++ b/lib/components/Header/styles.scss
@@ -85,10 +85,14 @@
     }
 
     .au-logo {
-      max-width: 56px;
-
       img {
         width: 100%;
+      }
+    }
+
+    &--limited-width {
+      .au-logo {
+        max-width: 56px;
       }
     }
   }


### PR DESCRIPTION
Conditionally allow header badges to expand.

before:
<img width="881" alt="Captura de Tela 2025-06-26 às 18 43 07" src="https://github.com/user-attachments/assets/6adef5bf-8ff7-49c5-bc87-0f2fb38ff6c5" />

after (with limitBadgeWidth as `false`):

<img width="874" alt="Captura de Tela 2025-06-26 às 18 44 30" src="https://github.com/user-attachments/assets/982dcde6-faaf-42ab-ad2e-2484991e6ae2" />
