### PR TITLE
feat: add open manually tooltip prop

### DIFF
--- a/lib/components/Tooltip/Tooltip.stories.tsx
+++ b/lib/components/Tooltip/Tooltip.stories.tsx
@@ -58,3 +58,12 @@ export const Right: Story = {
     children: <IconHelpCircle />,
   },
 }
+
+export const OpenManually: Story = {
+  args: {
+    text: 'Tooltip text',
+    position: 'top',
+    open: true,
+    children: <IconHelpCircle />,
+  },
+}

--- a/lib/components/Tooltip/index.tsx
+++ b/lib/components/Tooltip/index.tsx
@@ -1,14 +1,29 @@
+import classNames from 'classnames'
 import './styles.scss'
 
 export type TooltipProps = {
   text: string
   position?: 'top' | 'bottom' | 'left' | 'right'
+  open?: boolean
   children: React.ReactNode
 }
 
-export const Tooltip = ({ text, position = 'top', children }: TooltipProps) => {
+export const Tooltip = ({
+  text,
+  position = 'top',
+  open,
+  children,
+}: TooltipProps) => {
+  const tooltipClasses = classNames(
+    'tooltip-container',
+    `tooltip-${position}`,
+    {
+      'tooltip-open': open,
+    },
+  )
+
   return (
-   <div className={`tooltip-container tooltip-${position}`}>
+    <div className={tooltipClasses}>
       {children}
       <div className="tooltip">{text}</div>
     </div>

--- a/lib/components/Tooltip/styles.scss
+++ b/lib/components/Tooltip/styles.scss
@@ -31,7 +31,7 @@
     }
   }
 
-  &:hover .tooltip {
+  &:hover .tooltip, &.tooltip-open .tooltip {
     visibility: visible;
     opacity: 1;
   }


### PR DESCRIPTION
Este PR possibilita o controle da exibição do balão do tooltip pela prop `open`
<img width="322" height="257" alt="image" src="https://github.com/user-attachments/assets/e1c6942e-52b9-4191-b01b-41ab6191f53c" />
