### PR TITLE
fix: remove 'does not render when closed' drawer test

### DIFF
--- a/lib/components/Drawer/Drawer.test.tsx
+++ b/lib/components/Drawer/Drawer.test.tsx
@@ -20,20 +20,6 @@ describe('Drawer', () => {
     expect(getByText('Drawer Content')).toBeInTheDocument()
   })
 
-  it('does not render when closed', () => {
-    const { queryByText } = render(
-      <Drawer
-        isOpen={false}
-        handleOpen={vi.fn()}
-        renderHeader={<h1>Header</h1>}
-        renderContent={<p>Drawer Content</p>}
-      />,
-    )
-
-    expect(queryByText('Header')).not.toBeInTheDocument()
-    expect(queryByText('Drawer Content')).not.toBeInTheDocument()
-  })
-
   it('calls handleOpen when the close button is clicked', () => {
     const handleOpenMock = vi.fn()
     const { container } = render(

--- a/lib/components/Drawer/index.tsx
+++ b/lib/components/Drawer/index.tsx
@@ -16,8 +16,6 @@ export const Drawer = ({
   isOpen = false,
   handleOpen,
 }: DrawerProps) => {
-
-  if (!isOpen) return null
   
   return (
     <div


### PR DESCRIPTION
o Drawer precisa estar no documento para a animação funcionar. Vou remover esse teste por enquanto.