### PR TITLE
fix: 🐛 prevent default in alert action click

### DIFF
--- a/lib/components/Alert/index.tsx
+++ b/lib/components/Alert/index.tsx
@@ -77,7 +77,9 @@ export const Alert = ({
     }
   }, [timeLeft])
 
-  const handleActionClick = () => {
+  const handleActionClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+		event.preventDefault();
+		
     setTimeLeft(countdown)
     setIsCountdownFinished(false)
     actionButton?.onClick?.()
@@ -153,7 +155,7 @@ export const Alert = ({
             renderIf={
               <button
                 className="au-alert__action-btn"
-                onClick={handleActionClick}>
+                onClick={(e) => handleActionClick(e)}>
                 {actionButton?.content}
               </button>
             }


### PR DESCRIPTION
Alert action component is triggering form submits.
It also call API when the form is valid, even without a click in the main CTA of the form

* this PR add a preventDefault for this click event

<img width="944" height="775" alt="image" src="https://github.com/user-attachments/assets/1d57703c-8747-41e8-977a-a8a4f19e865b" />

