### PR TITLE
chore: 👷 fix push to main after a PR

### DIFF
--- a/.github/workflows/publish-lib.yml
+++ b/.github/workflows/publish-lib.yml
@@ -1,7 +1,5 @@
 name: Publish Lib (npm)
 on:
-  # When Release Pull Request is merged
-  workflow_dispatch:
   pull_request:
     branches:
       - main
@@ -27,11 +25,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.ref }}
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 18.18.0
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Git Identity
         run: |
@@ -45,15 +45,20 @@ jobs:
           npm ci
 
       - name: Bump version
-        run: npm version patch
+        run: npm version patch --no-git-tag-version
+
+      - name: Commit version bump
+        run: |
+          git add package.json
+          git commit -m "chore: bump version to $(node -p "require('./package.json').version")"
+
+      - name: Create Git Tag
+        run: git tag v$(node -p "require('./package.json').version")
 
       - name: Build lib
         run: npm run build
-      
-      - name: Push Changes
-        run: git push --follow-tags
 
-      - uses: JS-DevTools/npm-publish@v3
+      - name: Publish to npm
+        uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
-

--- a/lib/components/Alert/index.tsx
+++ b/lib/components/Alert/index.tsx
@@ -77,7 +77,6 @@ export const Alert = ({
     }
   }, [timeLeft])
 	
-
   const handleActionClick = (event: React.MouseEvent<HTMLButtonElement>) => {
 		event.preventDefault();
 		


### PR DESCRIPTION
This action must be changed after we add push to `main` protection (apparently added recently)

In the current action, Publish Lib (npm) workflow is triggered when a pull request to main is closed (meaning it's merged). At this point, the actions/checkout step fetches the main branch. Then, the workflow tries to run npm version patch and git push --follow-tags.

The git push --follow-tags attempts to push new commits and tags directly to the main branch. (that now is blocked)