### PR TITLE
fix: 🐛 add button type to action button

### DIFF
--- a/lib/components/Alert/index.tsx
+++ b/lib/components/Alert/index.tsx
@@ -155,6 +155,7 @@ export const Alert = ({
             renderIf={
               <button
                 className="au-alert__action-btn"
+								type="button"
                 onClick={(e) => handleActionClick(e)}>
                 {actionButton?.content}
               </button>


### PR DESCRIPTION
* the fact that this element has not a type attribute, the onClick was being triggered by and enter in the father component form