### PR TITLE
Feat/badge state

### DIFF
--- a/lib/components/BadgeState/BadgeState.stories.tsx
+++ b/lib/components/BadgeState/BadgeState.stories.tsx
@@ -1,0 +1,134 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { BadgeState, BadgeStateProps } from '.'
+
+const meta: Meta<BadgeStateProps> = {
+  title: 'Components/BadgeState',
+  component: BadgeState,
+  tags: ['autodocs'],
+  parameters: {
+    backgrounds: {
+      default: 'default',
+      values: [{ name: 'default', value: '#f1f1f1' }],
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof BadgeState>
+
+const container = (args: BadgeStateProps) => {
+  return <BadgeState {...args} />
+}
+
+export const InfoTextBadge: Story = {
+  render: (args) => container(args),
+  args: {
+    status: 'info',
+    text: 'Info',
+  },
+}
+
+export const SuccessTextBadge: Story = {
+  render: (args) => container(args),
+  args: {
+    status: 'success',
+    text: 'Success',
+  },
+}
+
+export const WarningTextBadge: Story = {
+  render: (args) => container(args),
+  args: {
+    status: 'warning',
+    text: 'Warning',
+  },
+}
+
+export const SupportTextBadge: Story = {
+  render: (args) => container(args),
+  args: {
+    status: 'support',
+    text: 'Support',
+  },
+}
+
+export const ErrorTextBadgeStrong: Story = {
+  render: (args) => container(args),
+  args: {
+    status: 'error',
+    text: 'Error',
+    variant: 'strong',
+  },
+}
+
+export const WarningTextBadgeStrong: Story = {
+  render: (args) => container(args),
+  args: {
+    status: 'warning',
+    text: 'Warning',
+    variant: 'strong',
+  },
+}
+
+export const SupportIconBadge: Story = {
+  render: (args) => container(args),
+  args: {
+    status: 'support',
+    iconOnly: true,
+  },
+}
+
+export const InfoIconBadge: Story = {
+  render: (args) => container(args),
+  args: {
+    status: 'info',
+    iconOnly: true,
+  },
+}
+
+export const ErrorIconBadgeStrong: Story = {
+  render: (args) => container(args),
+  args: {
+    status: 'error',
+    iconOnly: true,
+    variant: 'strong',
+  },
+}
+
+export const SuccessIconBadgeStrong: Story = {
+  render: (args) => container(args),
+  args: {
+    status: 'success',
+    iconOnly: true,
+    variant: 'strong',
+  },
+}
+
+export const SupportIconBadgeStrong: Story = {
+  render: (args) => container(args),
+  args: {
+    status: 'support',
+    iconOnly: true,
+    variant: 'strong',
+  },
+}
+
+export const NumberErrorBadge: Story = {
+  render: (args) => container(args),
+  args: {
+    status: 'error',
+    text: '99',
+    isNumberBadge: true,
+  },
+}
+
+export const NumberWarningBadgeStrong: Story = {
+  render: (args) => container(args),
+  args: {
+    status: 'warning',
+    text: '1',
+    isNumberBadge: true,
+    variant: 'strong',
+  },
+}

--- a/lib/components/BadgeState/BadgeState.test.tsx
+++ b/lib/components/BadgeState/BadgeState.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { BadgeState } from '.'
+
+describe('BadgeState', () => {
+  describe('Basic rendering', () => {
+    it('renders text content with default props', () => {
+      render(<BadgeState status="info" text="Info badge" />)
+      
+      expect(screen.getByText('Info badge')).toBeInTheDocument()
+    })
+
+    it('applies base CSS classes correctly', () => {
+      render(<BadgeState status="info" text="Test" />)
+      
+      const container = screen.getByText('Test').closest('.au-badgeState')
+      expect(container).toHaveClass('au-badgeState')
+      expect(container).toHaveClass('au-badgeState--info')
+      expect(container).toHaveClass('au-badgeState--variant-regular')
+    })
+
+    it('renders children when provided', () => {
+      render(
+        <BadgeState status="info" text="Test">
+          <span data-testid="child">Child content</span>
+        </BadgeState>
+      )
+      
+      expect(screen.getByTestId('child')).toBeInTheDocument()
+    })
+  })
+
+  describe('Status variants', () => {
+    const statuses = ['info', 'success', 'error', 'warning', 'support'] as const
+
+    statuses.forEach(status => {
+      it(`renders ${status} status with correct class`, () => {
+        render(<BadgeState status={status} text="Test" />)
+        
+        const container = screen.getByText('Test').closest('.au-badgeState')
+        expect(container).toHaveClass(`au-badgeState--${status}`)
+      })
+    })
+
+    it('renders success status with check icon in icon-only mode', () => {
+      const { container } = render(<BadgeState status="success" iconOnly />)
+      
+      expect(container.querySelector('.au-icon')).toBeInTheDocument()
+      expect(container.querySelector('.au-badgeState--icon-only')).toBeInTheDocument()
+    })
+  })
+
+  describe('Variant modes', () => {
+    it('applies regular variant by default', () => {
+      render(<BadgeState status="info" text="Test" />)
+      
+      const container = screen.getByText('Test').closest('.au-badgeState')
+      expect(container).toHaveClass('au-badgeState--variant-regular')
+    })
+
+    it('applies strong variant when specified', () => {
+      render(<BadgeState status="info" text="Test" variant="strong" />)
+      
+      const container = screen.getByText('Test').closest('.au-badgeState')
+      expect(container).toHaveClass('au-badgeState--variant-strong')
+    })
+  })
+
+  describe('Icon-only mode', () => {
+    it('shows only icon when iconOnly is true', () => {
+      const { container } = render(<BadgeState status="info" iconOnly />)
+      
+      expect(container.querySelector('.au-icon')).toBeInTheDocument()
+      expect(container).toHaveClass('au-badgeState--icon-only')
+      expect(screen.queryByText('text')).not.toBeInTheDocument()
+    })
+
+    it('shows text when iconOnly is false', () => {
+      render(<BadgeState status="info" text="Test text" iconOnly={false} />)
+      
+      expect(screen.getByText('Test text')).toBeInTheDocument()
+    })
+  })
+
+  describe('Number badge mode', () => {
+    it('applies border-circle class when isNumberBadge is true', () => {
+      render(<BadgeState status="info" text="1" isNumberBadge />)
+      
+      const container = screen.getByText('1').closest('.au-badgeState')
+      expect(container).toHaveClass('au-badgeState--border-circle')
+    })
+
+    it('does not apply border-circle class by default', () => {
+      render(<BadgeState status="info" text="Test" />)
+      
+      const container = screen.getByText('Test').closest('.au-badgeState')
+      expect(container).not.toHaveClass('au-badgeState--border-circle')
+    })
+  })
+
+  describe('Combined props scenarios', () => {
+    it('handles icon-only with strong variant', () => {
+      const { container } = render(
+        <BadgeState status="error" iconOnly variant="strong" />
+      )
+      
+      const badgeElement = container.querySelector('.au-badgeState')
+      expect(badgeElement).toHaveClass('au-badgeState--icon-only')
+      expect(badgeElement).toHaveClass('au-badgeState--variant-strong')
+      expect(badgeElement).toHaveClass('au-badgeState--error')
+    })
+
+    it('handles number badge with strong variant', () => {
+      render(<BadgeState status="success" text="99" isNumberBadge variant="strong" />)
+      
+      const container = screen.getByText('99').closest('.au-badgeState')
+      expect(container).toHaveClass('au-badgeState--border-circle')
+      expect(container).toHaveClass('au-badgeState--variant-strong')
+      expect(container).toHaveClass('au-badgeState--success')
+    })
+  })
+})

--- a/lib/components/BadgeState/BadgeState.test.tsx
+++ b/lib/components/BadgeState/BadgeState.test.tsx
@@ -71,8 +71,11 @@ describe('BadgeState', () => {
       const { container } = render(<BadgeState status="info" iconOnly />)
       
       expect(container.querySelector('.au-icon')).toBeInTheDocument()
-      expect(container).toHaveClass('au-badgeState--icon-only')
-      expect(screen.queryByText('text')).not.toBeInTheDocument()
+      
+      const badgeElement = container.querySelector('.au-badgeState')
+      expect(badgeElement).toHaveClass('au-badgeState--icon-only')
+      
+      expect(container.querySelector('.au-badgeState__content-support-text')).not.toBeInTheDocument()
     })
 
     it('shows text when iconOnly is false', () => {

--- a/lib/components/BadgeState/index.tsx
+++ b/lib/components/BadgeState/index.tsx
@@ -1,0 +1,79 @@
+import classNames from 'classnames'
+import {
+  IconAlertOctagon,
+  IconAlertTriangle,
+  IconCheck,
+  IconMoreHorizontal,
+  IconInfo,
+} from '@components/icons'
+import {
+  COLOR_ERROR_50,
+  COLOR_INFO_50,
+  COLOR_SUCCESS_50,
+  COLOR_WARNING_50,
+  COLOR_BRAND_CYAN_50,
+} from '@core/tokens'
+
+import { IfElse, Else, Then } from '@components/misc'
+
+import './styles.scss'
+
+export type BadgeStateProps = {
+  status: 'info' | 'success' | 'error' | 'warning' | 'support'
+  isNumberBadge?: boolean
+  variant?: 'regular' | 'strong'
+  text?: string
+  children?: React.ReactNode
+  icon?: string | JSX.Element
+  iconOnly?: boolean
+}
+
+export const BadgeState = ({
+  status,
+  isNumberBadge = false,
+  variant = 'regular',
+  iconOnly = false,
+  text,
+  children,
+}: BadgeStateProps) => {
+  const statusMap = {
+    success: {
+      option: 'success',
+      icon: <IconCheck rawColor={COLOR_SUCCESS_50} />,
+    },
+    error: {
+      option: 'error',
+      icon: <IconAlertOctagon rawColor={COLOR_ERROR_50} />,
+    },
+    warning: {
+      option: 'warning',
+      icon: <IconAlertTriangle rawColor={COLOR_WARNING_50} />,
+    },
+    info: { option: 'info', icon: <IconInfo rawColor={COLOR_INFO_50} /> },
+    support: {
+      option: 'support',
+      icon: <IconMoreHorizontal rawColor={COLOR_BRAND_CYAN_50} />,
+    },
+  }
+
+  const badgeStateClasses = classNames('au-badgeState', {
+    [`au-badgeState--${statusMap[status].option}`]: statusMap[status].option,
+    [`au-badgeState--border-circle`]: !!isNumberBadge,
+    [`au-badgeState--icon-only`]: !!iconOnly,
+    [`au-badgeState--variant-${variant}`]: !!variant,
+  })
+
+  return (
+    <div className={badgeStateClasses}>
+      <div className="au-badgeState__content">
+        <IfElse condition={!!iconOnly}>
+          <Then>{statusMap[status].icon}</Then>
+          <Else>
+            {<p className={`au-badgeState__content-support-text`}>{text}</p>}
+          </Else>
+        </IfElse>
+      </div>
+      {children}
+    </div>
+  )
+}

--- a/lib/components/BadgeState/styles.scss
+++ b/lib/components/BadgeState/styles.scss
@@ -12,14 +12,13 @@
     justify-content: center;
     align-items: center;
       .au-icon > svg {
-        width: 16px;
-        height: 16px;
+        width: 14px;
+        height: 14px;
       }
 
     &-support-text {
       font-size: 12px;
       font-weight: 600;
-      line-height: 150%;
     }
   }
 
@@ -28,7 +27,7 @@
   &--icon-only{
     width: 20px;
     height: 20px;
-    padding: 20px;
+    padding: 4px;
   }
 
    &--variant-strong {
@@ -44,7 +43,9 @@
     aspect-ratio: 1;
     display: flex;
     justify-content: center;
-    padding: 4px 6px;
+    align-items: center;
+    padding: 4px;
+    align-content: center;
   }
 
   &--variant-regular {

--- a/lib/components/BadgeState/styles.scss
+++ b/lib/components/BadgeState/styles.scss
@@ -1,0 +1,91 @@
+.au-badgeState {
+  font-family: $font-body;
+  display: flex;
+  justify-content: center;
+  border-radius: 8px;
+  padding: 4px 6px;
+  width: fit-content;
+
+  &__content {
+    display: flex;
+    gap: 8px;
+    justify-content: center;
+    align-items: center;
+      .au-icon > svg {
+        width: 16px;
+        height: 16px;
+      }
+
+    &-support-text {
+      font-size: 12px;
+      font-weight: 600;
+      line-height: 150%;
+    }
+  }
+
+  // VARIANTES
+
+  &--icon-only{
+    width: 20px;
+    height: 20px;
+    padding: 20px;
+  }
+
+   &--variant-strong {
+      .au-icon{
+      color: $color-neutral-00 !important;
+      }
+    }
+
+  &--border-circle {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    aspect-ratio: 1;
+    display: flex;
+    justify-content: center;
+    padding: 4px 6px;
+  }
+
+  &--variant-regular {
+    &.au-badgeState--info {
+      background-color: $color-info-10;
+      color: $color-info-60;
+    }
+    &.au-badgeState--success {
+      background-color: $color-success-10;
+      color: $color-success-50;
+    }
+    &.au-badgeState--error {
+      background-color: $color-error-10;
+      color: $color-error-50;
+    }
+    &.au-badgeState--warning {
+      background-color: $color-warning-10;
+      color: $color-warning-60;
+    }
+    &.au-badgeState--support {
+      background-color: $color-brand-cyan-10;
+      color: $color-brand-cyan-60;
+    }
+  }
+
+  &--variant-strong {
+    color: $color-neutral-00;
+    &.au-badgeState--info {
+      background-color: $color-info-50;
+    }
+    &.au-badgeState--success {
+      background-color: $color-success-50;
+    }
+    &.au-badgeState--error {
+      background-color: $color-error-50;
+    }
+    &.au-badgeState--warning {
+      background-color: $color-warning-50;
+    }
+    &.au-badgeState--support {
+      background-color: $color-brand-cyan-50;
+    }
+  }
+}


### PR DESCRIPTION
Criação do badge state, que tem as variantes:
- `variant`: strong ou regular
- `iconOnly`: true ou false
- `isNumberBadge`: true ou false
- `status`: 'info' | 'success' | 'error' | 'warning' | 'support'

Se a badge possuir icone, nao possui texto. 

<img width="1074" height="564" alt="image" src="https://github.com/user-attachments/assets/de837253-a1fd-4355-ac1e-0e15428ebd63" />
<img width="1063" height="571" alt="image" src="https://github.com/user-attachments/assets/2c7b2da4-2533-40da-a0b7-a6df021c6e30" />
