### PR TITLE
fix: 🐛 corrige scroll vertical fantasma e key faltando no Tabs

### DIFF
--- a/lib/components/Tabs/index.tsx
+++ b/lib/components/Tabs/index.tsx
@@ -89,7 +89,7 @@ export const Tabs = ({
               <div className="au-tabs__btns" ref={tabsRef}>
                 {tabs.map((item: TabItemProps) => {
                   return (
-                    <Switch>
+                    <Switch key={item.tab}>
                       <Case condition={type === 1}>
                         <Chip
                           label={item.title}

--- a/lib/components/Tabs/styles.scss
+++ b/lib/components/Tabs/styles.scss
@@ -41,8 +41,8 @@
     display: flex;
     position: relative;
     white-space: nowrap;
-    white-space: nowrap;
-    overflow-x: scroll;
+    overflow-x: auto;
+    overflow-y: hidden;
     margin-bottom: 20px;
 
     &::-webkit-scrollbar {

--- a/lib/components/Tabs/styles.scss
+++ b/lib/components/Tabs/styles.scss
@@ -40,6 +40,7 @@
   &__btns {
     display: flex;
     position: relative;
+    white-space: nowrap;
     overflow-x: scroll;
     overflow-y: hidden;
     margin-bottom: 20px;

--- a/lib/components/Tabs/styles.scss
+++ b/lib/components/Tabs/styles.scss
@@ -40,8 +40,7 @@
   &__btns {
     display: flex;
     position: relative;
-    white-space: nowrap;
-    overflow-x: auto;
+    overflow-x: scroll;
     overflow-y: hidden;
     margin-bottom: 20px;
 


### PR DESCRIPTION
## Summary
Corrige dois problemas no componente Tabs: um warning de key faltando no React e um leve scroll fantasma no eixo Y do `au-tabs__btns`.

- Adiciona `key={item.tab}` ao `Switch` dentro do `tabs.map` para resolver o warning de key em listas do React
- Define `overflow-y: hidden` no `au-tabs__btns` para eliminar o scroll vertical implícito (quando `overflow-x` ≠ `visible`, o eixo Y vira `auto` automaticamente)
- Troca `overflow-x: scroll` por `auto` (scrollbar só quando necessário) e remove `white-space: nowrap` duplicado

🤖 Generated with [Claude Code](https://claude.com/claude-code)