### PR TITLE
chore(ai): configura repo para agentes no padrão da CP (cp-repo-setup)

### DIFF
--- a/.ai-docs/README.md
+++ b/.ai-docs/README.md
@@ -1,0 +1,14 @@
+# `.ai-docs/` — documentação viva para humanos e agentes
+
+Docs em **linguagem de negócio**, lidas por não-técnicos (design, produto, PMs, times consumidores) via o MCP `github-readonly` no Claude.ai, e por agentes que investigam o repo. Complementa (não substitui) o `CLAUDE.md` raiz (técnico) e `docs/` (referência longa).
+
+## Dois eixos
+
+- **`services/<serviço>.md`** — DURÁVEL: o que o sistema faz e por quê. Pareado 1:1 com a camada técnica (aqui: o `CLAUDE.md` raiz). Formato de seções de negócio. Atualiza quando o comportamento/contrato visível muda. Neste repo, o "serviço" é o próprio design system → `services/aurora.md`.
+- **`missions/<missão>.md`** — TIME-BOUND: missões (Shape Up) e mudanças não-triviais em voo. O elo entre o pitch (Notion) e o que foi feito. Tem `ttl_review` e é podado/arquivado depois (3 meses pontual / 6 missão).
+
+## Regras
+- Linguagem de negócio, português, 1–3 páginas. Termo técnico só com explicação.
+- `missions/` **linka** o pitch no Notion — não duplica o contrato.
+- Self-improvement: PR que muda comportamento/contrato visível → atualiza o doc + changelog (ver `docs/self-improvement.md`).
+- Para criar/aprofundar um doc de serviço, use a skill `/cp-ai-doc`.

--- a/.ai-docs/services/aurora.md
+++ b/.ai-docs/services/aurora.md
@@ -1,0 +1,68 @@
+# Aurora — Design System — `aurora`
+
+> **Audiência:** design, produto, PMs e times de front-end que consomem a biblioteca; agentes investigando.
+> **Técnico (como mexer):** `CLAUDE.md` na raiz · **Código:** `lib/` · **Explorador visual:** Storybook
+>
+> _Documento inicial gerado pelo setup de IA (`cp-repo-setup`). Aprofundar com a skill `/cp-ai-doc`._
+
+## Em uma frase
+Aurora é a biblioteca de componentes de interface compartilhada entre **Consumidor Positivo** e **Acordo Certo** — o lugar único onde vivem botões, formulários, cabeçalhos e os tokens de marca das duas BUs.
+
+## O que esse serviço faz
+Padroniza a aparência e o comportamento das telas das duas marcas. Em vez de cada app reimplementar um botão ou um campo de formulário, todos instalam o pacote `@consumidor-positivo/aurora` e usam os mesmos componentes. Isso garante consistência visual, acessibilidade e velocidade: uma melhoria feita aqui chega a todos os produtos que atualizam a versão.
+
+Aurora entrega três coisas:
+- **Componentes** reutilizáveis de UI (Button, Card, Tabs, formulários, Header/Footer, etc.).
+- **Tokens de design** (cores, tipografia, espaçamento) que codificam a identidade visual de cada marca.
+- **Ícones** padronizados.
+
+## Quando ele "roda" (gatilhos)
+| Gatilho | O que acontece |
+|---|---|
+| Um app consumidor instala/atualiza o pacote | Passa a usar os componentes/tokens da versão escolhida |
+| Um PR com `feat`/`fix` é mergeado na `main` | Sai uma nova versão no npm automaticamente (release-please) e o Storybook é republicado |
+| Designer/dev abre o Storybook | Vê a documentação viva: como cada componente se parece e se comporta |
+
+Aurora não tem "produção" própria — ela executa **dentro** dos apps que a instalam.
+
+## O que entra e o que produz
+- **Entra:** decisões de design (tokens, novos componentes, ajustes de marca) e correções.
+- **Produz:** um pacote npm versionado + um site de documentação (Storybook) hospedado.
+
+## Decisões de negócio embutidas
+- **Duas marcas, uma base:** componentes com variação de marca (ex.: Footer, Logo) têm versões `cp/` e `ac/`. A escolha de marca é do app consumidor.
+- **Contrato é compromisso:** mudar props, classes CSS (`au-`) ou tokens públicos **quebra** os apps que dependem deles. Por isso o versionamento é semântico e automático pelos commits.
+- **Acessibilidade como padrão:** há auditoria de acessibilidade (skill `/accessibility-audit`, critérios WCAG 2.1 AA).
+- **Bundle enxuto:** componentes que exigem dependências pesadas (ex.: Carousel → `react-snap-carousel`) são opcionais e não entram por padrão.
+
+## Cenários comuns
+- **"Quero um componente novo no design system"** → é criado seguindo o padrão (skill `/create-component`), documentado no Storybook e publicado numa nova versão.
+- **"O botão mudou de cor sem avisar"** → provavelmente o app atualizou a versão de Aurora; o que mudou está no `CHANGELOG.md`.
+- **"Posso usar Aurora no meu app novo?"** → sim, `npm install @consumidor-positivo/aurora`; ver README e Storybook.
+
+## Limitações e dívidas técnicas relevantes pro negócio
+- Componentes em `lib/components/Prototype/` são **experimentais** (ex.: Carousel) e exigem dependências extras.
+- Alguns exports estão marcados para depreciação no código (ex.: `Conditional`).
+- _(A preencher com `/cp-ai-doc` conforme o time priorizar.)_
+
+## Como se conecta a outros sistemas
+```
+        ┌──────────────────────────────┐
+        │   Aurora (este repo)          │
+        │   componentes · tokens · ícones│
+        └───────────────┬──────────────┘
+                        │ publicado no npm
+        ┌───────────────┼───────────────┐
+        ▼               ▼               ▼
+   Site Consumidor   Site Acordo     Outros front-ends
+     Positivo          Certo          das duas BUs
+```
+
+## Onde investigar mais
+- Técnico / como contribuir: `CLAUDE.md` (raiz).
+- Como o repo é observado / debug: `docs/observability.md`.
+- Documentação visual: Storybook (`npm run storybook` ou o build publicado).
+- Padrões e desenvolvimento com IA: `lib/docs/Patterns.mdx`, `lib/docs/DevelopingWithAI.mdx`.
+
+## Histórico de mudanças relevantes
+- 2026-06-30 — Documento inicial criado no setup de IA do repo (`cp-repo-setup`).

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,19 @@
+---
+name: code-reviewer
+description: Revisa mudanças aplicando os padrões deste repo (CLAUDE.md, convenções de Aurora) e os pilares da org. Read-only — não edita; reporta achados.
+tools: Read, Grep, Glob, Bash
+---
+
+Você revisa o diff atual deste repo (Aurora — design system React/SCSS). Antes de revisar:
+1. Leia o `CLAUDE.md` raiz (convenções de componente, CSS `au-`/BEM, tokens, prebuild).
+2. Aplique os pilares da org (menor solução primeiro; reaproveitar antes de criar; não expor PII; citar fonte).
+
+Cheque especificamente, além de correção geral:
+- **Contrato público:** mudou props, classes `au-` ou tokens exportados? → é potencialmente **breaking** para apps consumidores; o tipo de commit (`feat`/`fix`/`feat!`) precisa refletir isso (release-please).
+- **Tokens vs hardcode:** valores de cor/espaçamento/tipografia no SCSS devem usar tokens (`$color-*`, `$spacing-*`…), não valores crus.
+- **Arquivos gerados:** o diff não deve editar `lib/core/tokens/.cache/**` nem `lib/components/icons/**` (são gerados pelo prebuild).
+- **Acessibilidade:** semântica, ARIA, foco e teclado nos componentes interativos.
+- **Testes & lint:** mudança de componente acompanhada de teste; lint roda com `--max-warnings 0`.
+- **Skill nova?** se adicionou `.claude/skills/<x>/SKILL.md`, há seção correspondente em `lib/docs/DevelopingWithAI.mdx`?
+
+Reporte por severidade. Não edite arquivos. Priorize: correção > simplificação/reuso > estilo. Cite `file:line`.

--- a/.claude/agents/explorer.md
+++ b/.claude/agents/explorer.md
@@ -1,0 +1,17 @@
+---
+name: explorer
+description: Explorador read-only do repo Aurora. Localiza componentes, tokens, ícones e convenções e devolve a conclusão (não dumps). Use para mapear onde algo mora antes de mexer.
+tools: Read, Grep, Glob, Bash
+---
+
+Você localiza e resume — não edita. Dado um alvo (componente, token, ícone, padrão), encontre onde mora e devolva uma conclusão enxuta: onde está, o que faz, dependências e o que ler antes de mexer.
+
+Mapa de orientação do repo:
+- Componentes: `lib/components/<Nome>/` (`index.tsx`, `styles.scss`, `types.ts`, `hooks.ts`, `*.stories.tsx`, `*.test.tsx`). Variantes de marca em `ac/` e `cp/`.
+- Exports públicos: `lib/main.ts`.
+- Tokens (fonte): `lib/core/tokens/*.json` → gerados em `lib/core/tokens/.cache/` (não editar à mão).
+- Ícones (fonte): `lib/assets/icons/<coleção>/` → gerados em `lib/components/icons/` (não editar à mão).
+- Docs Storybook: `lib/docs/*.mdx`. Docs de negócio: `.ai-docs/`. Referência/observabilidade: `docs/`.
+- Aliases: `@components`, `@core`, `@assets`.
+
+Antes de concluir, aponte qual doc ler (`CLAUDE.md`, story, `.ai-docs/services/aurora.md`) e se a mudança toca contrato público. Conclusão enxuta, não despejo de arquivos.

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: create-pr
+description: >
+  Cria um branch a partir da main e abre um pull request com título de commit
+  convencional, descrição estruturada e labels — incluindo as tags
+  constitucionais da Consumidor Positivo: classificação de custo (CapEx/OpEx),
+  risco, prioridade, impacto e escopo. Use ao abrir um PR neste repo. Mantém
+  também as regras específicas de Aurora (release-please, prebuild, lint).
+---
+
+# Create Pull Request (baseline constitucional da CP)
+
+> Este é o **baseline da org** instalado pela `cp-repo-setup`. As **regras específicas do repo** (release-please, prebuild, lint, arquivos gerados) ficam na seção "Regras deste repo" no fim — **não as remova**.
+
+## Objetivo
+Criar branch a partir de `main`, commitar, push e abrir um PR com descrição clara e as **labels constitucionais** (custo CapEx/OpEx, risco, prioridade, impacto, escopo).
+
+## Passo 1 — Branch a partir da main
+```bash
+git checkout main && git pull origin main
+git checkout -b <tipo>/<descrição-curta>   # feat/ fix/ chore/ refactor/ docs/
+```
+Convenção de branch: `{tipo}/{descrição}`. Title em conventional commit: `{tipo}({escopo}): {descrição}` (1ª linha < 72 chars).
+
+## Passo 2 — Commit & push
+```bash
+git add <arquivos>
+git commit -m "<conventional commit>"
+git push origin <branch>
+```
+Use só arquivos do diff (`git diff --name-only main`) — ignore untracked/`.gitignore`.
+
+## Passo 3 — Descobrir o repo (sem hardcode)
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+```
+
+## Passo 4 — Labels constitucionais (toda PR)
+Aplique de **cada categoria aplicável**. Mínimo: 1 de custo, 1 de risco, 1 de prioridade, 1+ de escopo. Crie a label se não existir (Passo 5).
+
+### 4a. Custo — CapEx / OpEx — OBRIGATÓRIO
+> **Todo PR carrega exatamente UMA label de custo** (`capex:<slug>` **ou** `opex`).
+
+1. **Leia os slugs canônicos** (NÃO mantenha cópia neste repo) — consulte a skill org **`cp-capex`**. Ali estão os projetos **abertos** + a regra de classificação.
+2. **Classifique:** projeto capex aberto (missão / rebuild / AI / dados) → `capex:<slug>`; caso contrário (manutenção da lib, ajuste em componente entregue) → `opex`. Na dúvida → pergunte; não invente slug.
+
+### 4b. Risco
+`low-risk` (docs/config, sem lógica) · `medium-risk` (componente com testes, backward-compatible) · `high-risk` (breaking na API pública, mudança de token global, sem testes).
+
+### 4c. Prioridade
+`priority: low` · `priority: medium` · `priority: high` · `priority: critical`.
+
+### 4d. Impacto
+`impact: feature` · `impact: reliability` · `impact: performance` · `impact: tech-debt` · `impact: dx` · `impact: a11y` (acessibilidade) · `impact: security`.
+
+### 4e. Escopo
+`front-end` (sempre aplicável aqui) · `scope: <componente>` (ex.: `scope: button`, `scope: tokens`, `scope: icons`) · `scope: cp` / `scope: ac` quando a mudança é de uma marca.
+
+### 4f. Tipo de mudança (se aplicável)
+`bug` · `documentation` · `dependencies` · `AI` (skills/agents/prompts).
+
+## Passo 5 — Criar labels que faltam
+```bash
+gh label list --repo "$REPO" --search "<label>" | cat
+gh label create "<label>" --color "<hex>" --description "<desc>" --repo "$REPO" 2>/dev/null || true
+```
+Cores: `capex:*` = `0E8A16` / `opex` = `5319E7`; `scope:*` = `D4C5F9`.
+
+## Passo 6 — Descrição do PR + footer de missão
+Corpo: Summary · Changes · Breaking? (props/classes `au-`/tokens) · Testing. **Se o PR pertence a uma missão** (`.ai-docs/missions/`), some `Mission: <slug>` no footer.
+```bash
+gh pr create --repo "$REPO" --title "<title>" --body-file /tmp/pr-body.md \
+  --label "capex:<slug>|opex" --label "<risco>" --label "priority: <p>" --label "front-end"
+```
+
+---
+
+## Regras deste repo (Aurora)
+
+### O título do commit/PR decide a versão — release-please é automático
+O versionamento e o `CHANGELOG.md` são gerados pelo **release-please** a partir dos commits convencionais que entram na `main` (ver `.github/workflows/release.yml`). O **tipo no título importa**:
+- `feat:` → bump **minor** + publica nova versão no npm.
+- `fix:` / `refactor:` → bump **patch** + publica.
+- `docs:` / `chore:` / `test:` → entram no changelog, **sem bump** (não publicam sozinhos).
+- `ci:` → oculto no changelog.
+- **Breaking** (mudança incompatível em props, classes `au-` ou tokens públicos): use `feat!:`/`fix!:` ou `BREAKING CHANGE:` no corpo → bump **major**. Apps consumidores dependem desse contrato — sinalize sempre.
+
+### Antes de abrir o PR (espelha o CI `aurora-tests.yml`)
+1. Se mexeu em `lib/core/tokens/*.json` ou em SVGs de `lib/assets/icons/` → rode `npm run prebuild` (regenera tokens + ícones).
+2. `npm run lint` — precisa passar com `--max-warnings 0`.
+3. `npm test` (o CI roda `test:coverage`).
+4. Para mudança que afeta o build da lib: `npm run build`.
+
+### Nunca commite arquivos gerados
+`lib/core/tokens/.cache/**` e `lib/components/icons/**` são gerados pelo prebuild. Não os inclua no diff — regenere, não edite à mão.
+
+### Adicionou/alterou uma skill?
+Atualize `lib/docs/DevelopingWithAI.mdx` com a seção da skill (regra do `CLAUDE.md`; há hook `PostToolUse` que lembra). Marque o PR com a label `AI`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,3 +98,32 @@ Project skills live in `.claude/skills/`. Each skill is a directory with a `SKIL
 ## Testing
 
 Tests use Vitest with jsdom and `@testing-library/react`. Setup is in `vitest.setup.ts`. Generated files (`lib/components/icons/default/**`, `lib/components/Logo/ac/**`, `lib/components/Logo/cp/**`) are excluded from test runs and coverage.
+
+## Releases & commits
+
+Versioning and `CHANGELOG.md` are automated by **release-please** (`.github/workflows/release.yml`) from the conventional commits merged into `main`. The commit/PR title type drives the bump: `feat:` → minor + npm publish, `fix:`/`refactor:` → patch + publish, `docs:`/`chore:`/`test:` → changelog only (no publish), breaking change (`feat!:` or `BREAKING CHANGE:`) → major. Since Aurora is consumed by external apps, changing public props, `au-` classes, or exported tokens is a **breaking change** — type the commit accordingly. The `/create-pr` skill encodes this.
+
+## Onde achar o resto (ponteiros)
+
+- **Referência longa & operação:** `docs/` — `docs/self-improvement.md` (protocolo que mantém os docs vivos) e `docs/observability.md` (onde investigar quando um componente quebra — Aurora é lib, não tem runtime próprio).
+- **Docs de negócio:** `.ai-docs/services/aurora.md` (o que é o design system, em linguagem de negócio — lido por design/produto via MCP `github-readonly`) e `.ai-docs/missions/` (mudanças não-triviais em voo). Aprofundar com `/cp-ai-doc`.
+- **Documentação no Storybook:** `lib/docs/*.mdx` (Configure, Patterns, Dependencies, Icons, DevelopingWithAI).
+- **Subagents read-only:** `.claude/agents/` (`code-reviewer`, `explorer`).
+
+## Contexto da organização (Consumidor Positivo)
+
+Brain central: repo `AcordoCertoBR/claude-org-context` (consulte via GitHub MCP / org-skills `cp-*` quando precisar).
+- Quem é dono de quê / qual squad / onde perguntar: `cp-org`. Convenções do brain: `cp-conventions`. Pilares de como o agente trabalha: `cp-pillars`.
+- Definições de métrica governadas: `cp-metrics` (raramente aplicável a uma lib de UI; relevante só se tocar telemetria/eventos).
+- As org-skills (`cp-*`) já estão no harness — não recrie contexto base aqui.
+- Aurora é consumida por apps externos das duas marcas (cp/ac); trate o contrato público (props, classes `au-`, tokens) como compromisso versionado.
+
+## Protocolo de auto-melhoria (OBRIGATÓRIO — ver `docs/self-improvement.md`)
+
+Este setup é vivo. Ao trabalhar neste repo, mantenha-o verdadeiro:
+- Mudou API/comportamento visível de um componente → atualize este `CLAUDE.md` e, se visível ao negócio/design, `.ai-docs/services/aurora.md` + changelog.
+- Criou/alterou uma skill em `.claude/skills/` → atualize `lib/docs/DevelopingWithAI.mdx` (regra do repo; há hook que lembra).
+- Descobriu gotcha/tech-debt → registre com `file:line` aqui.
+- Doc contradiz o código → corrija o doc (docs envelhecem; verifique contra o source).
+- Mudança não-trivial / missão → registro em `.ai-docs/missions/`.
+- Faltou cobertura nesta estrutura (padrão novo) → registre em `docs/setup-gaps.md` e sinalize ao brain (skill `cp-repo-setup`).

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,42 @@
+# Observabilidade & debug — Aurora
+
+> Mapa de **onde olhar** quando algo quebra. É fino de propósito: aponta, não duplica.
+>
+> ⚠️ **Aurora é uma biblioteca publicada no npm, não um serviço de runtime.** Ela não tem processo próprio em produção, não loga em Datadog, não escreve em Databricks e não roda em Lambda/EKS. O código de Aurora executa **dentro dos apps consumidores** (sites cp/ac e demais front-ends). Logo, a "observabilidade" aqui é sobre **o pacote publicado, a documentação visual (Storybook) e o CI** — e, quando um componente quebra em produção, a investigação acontece **no app consumidor**, reproduzindo em Storybook.
+
+## Superfícies reais deste repo
+
+### Pacote publicado (npm)
+- `@consumidor-positivo/aurora` — publicado automaticamente no merge para `main` quando o release-please cria um release (ver `.github/workflows/release.yml`).
+- Para saber o que está em produção: a versão **pinada no `package.json` de cada app consumidor** é a fonte da verdade — não a `main` daqui. Um bug "em produção" pode ser uma versão antiga pinada.
+- Histórico de versões: `CHANGELOG.md` (gerado pelo release-please a partir dos commits convencionais).
+
+### Storybook (documentação visual / explorador)
+- Build estático deployado em **S3 + CloudFront** no release (`release.yml`, job `publish`). É a referência viva de como cada componente deve parecer/comportar.
+- Primeira parada para reproduzir um bug visual ou de interação: rodar `npm run storybook` local ou abrir o Storybook publicado.
+- **Regressão visual:** `@chromatic-com/storybook` está nas devDeps → Chromatic pode rodar snapshots visuais. _(TODO: confirmar se o projeto Chromatic está ativo e onde ver os diffs.)_
+
+### CI (GitHub Actions)
+- `aurora-tests.yml` — em todo PR para `main`: `npm run prebuild` + `npm run test:coverage`. Falha aqui = não mergeia.
+- `release.yml` — no merge para `main`: release-please (versão + changelog) → `npm publish` → build + deploy do Storybook (S3/CloudFront).
+- Artefato de coverage fica retido 14 dias no run do CI.
+
+## Investigações comuns (playbook)
+
+| Sintoma | Onde olhar primeiro | Como |
+|---|---|---|
+| "Componente quebrado em produção no site cp/ac" | Versão de `@consumidor-positivo/aurora` pinada **no app consumidor** + o RUM/observabilidade **daquele app** | Confirme a versão instalada; reproduza no Storybook dessa versão. O bug pode não existir na `main`. |
+| "Visual diferente do esperado" | Storybook (local ou publicado) + tokens | `npm run storybook`; cheque se é token (`/token-audit`) ou CSS hardcoded. |
+| "Quebrou depois de atualizar a lib" | `CHANGELOG.md` + diff de versões | Procure `feat!`/`BREAKING CHANGE` ou mudança de props/classes `au-`/tokens entre as versões. |
+| "Token/ícone não aparece" | Geração no prebuild | Rode `npm run prebuild`; nunca edite `lib/core/tokens/.cache/` nem `lib/components/icons/` à mão. |
+| "Publish não saiu" | `release.yml` run | release-please só publica se criou release — e só cria com commit `feat`/`fix`/etc. na `main`. Cheque o tipo dos commits. |
+
+## Infra
+- Único recurso AWS deste repo: o **bucket S3 + CloudFront** que hospeda o Storybook estático (deploy no `release.yml`). Não há Lambda/EKS/fila.
+- ⚠️ **Convenção da org:** infra, dashboards e alertas Datadog moram no repo `infrastructure` como **Terraform** (centralizado) — ver `cp-conventions`. _(TODO: confirmar se o bucket/distribution do Storybook está versionado em Terraform no `infrastructure` ou foi criado manualmente.)_
+
+## Orientação ao agente (como investigar a partir deste repo)
+- Para bug **de runtime em produção**: a causa raiz raramente está na `main` daqui — comece pela **versão pinada e pela observabilidade do app consumidor**, depois reproduza em Storybook.
+- Para bug **de build/publish**: comece pelos runs de `aurora-tests.yml` / `release.yml` e pelos commits convencionais.
+- **Read-only por padrão.** Cite a fonte (run de CI, versão npm, story) na conclusão.
+- Datadog / AWS-runtime / Databricks: **N/A para esta lib** — não finja que existe.

--- a/docs/self-improvement.md
+++ b/docs/self-improvement.md
@@ -1,0 +1,38 @@
+# Protocolo de auto-melhoria do setup
+
+> O setup de IA deste repo não é um evento único — é um sistema vivo que melhora conforme os devs trabalham. Este protocolo define **o que dispara uma melhoria, quem a faz e como ela não apodrece**. Dois níveis: o repo se mantém verdadeiro (drift-closing) e a própria skill `cp-repo-setup` fica melhor (org-level).
+
+## Nível 1 — o repo se mantém verdadeiro (drift-closing)
+
+| Gatilho (quando) | Ação | Onde |
+|---|---|---|
+| PR muda a API/comportamento visível de um componente (props, classes `au-`, tokens públicos) | Atualizar o `CLAUDE.md` raiz e, se visível ao negócio/design, `.ai-docs/services/aurora.md` + changelog | `CLAUDE.md`, `.ai-docs/services/` |
+| Criou/alterou uma skill em `.claude/skills/` | Atualizar `lib/docs/DevelopingWithAI.mdx` com a seção da skill (há hook `PostToolUse` que lembra) | `lib/docs/DevelopingWithAI.mdx` |
+| Descoberta de gotcha / tech-debt | Registrar com `file:line` | `CLAUDE.md` raiz |
+| Doc contradiz o código | Corrigir o doc (verificar contra o source SEMPRE antes de confiar) | onde estiver |
+| Mudança não-trivial / missão (Shape Up) | Criar/atualizar registro de missão | `.ai-docs/missions/` |
+| Mudou tooling de build/tokens/icons | Refletir em `CLAUDE.md` (seção Prebuild) | `CLAUDE.md` raiz |
+
+**Mecanismos que sustentam isso (instalados pelo setup):**
+1. **Descoberta nativa:** repo de 1 serviço — o `CLAUDE.md` raiz já é a camada técnica e carrega no startup. Não há `CLAUDE.md` aninhado por componente (a árvore de componentes é homogênea; o padrão vive no raiz + nas skills `/create-component`, `/token-audit`, `/accessibility-audit`).
+2. **Hook de skill:** `PostToolUse` em `.claude/settings.json` lembra de atualizar `DevelopingWithAI.mdx` quando um novo `SKILL.md` é escrito.
+3. **Checklist no fim da sessão:** se a sessão mexeu em componente/API, o agente revisa este protocolo antes de fechar — atualizou os docs que precisava?
+4. **Auditoria sob demanda:** rodar a varredura (abaixo) periodicamente.
+
+## Nível 2 — a skill `cp-repo-setup` melhora (org-level)
+
+Quando o setup encontra um padrão que **não cobre bem** (stack nova, estrutura diferente, tooling novo), ele não improvisa em silêncio:
+- **Registra o gap** em `docs/setup-gaps.md` neste repo **e** sinaliza para o brain (`AcordoCertoBR/claude-org-context`, via issue ou PR) para que a org-skill `cp-repo-setup` seja melhorada centralmente.
+- Assim cada repo que passa pelo setup **alimenta o próximo** — a skill evolui com o uso real, não por adivinhação.
+
+> Exemplo concreto deste repo: o template de `observability.md` da `cp-repo-setup` assume um serviço de runtime (Datadog/AWS Lambda/Databricks). Aurora é uma **lib publicada no npm** sem runtime próprio — o `docs/observability.md` foi adaptado para essa realidade. Esse é exatamente o tipo de gap que vale registrar para a skill cobrir "biblioteca/pacote publicado" nativamente.
+
+## Auditoria (o que a varredura checa)
+- Componentes exportados em `lib/main.ts` cuja API mudou sem reflexo no `CLAUDE.md`/`.ai-docs`.
+- `.ai-docs/services/aurora.md` desatualizado vs. comportamento atual (amostra: datas de mudança vs. `git log`).
+- `.ai-docs/missions/` com `ttl_review` vencido → sugerir arquivar.
+- Skills em `.claude/skills/` sem seção correspondente em `lib/docs/DevelopingWithAI.mdx`.
+- Referências `file:line` que não existem mais (doc apodrecido).
+- Gaps acumulados em `setup-gaps.md` ainda não levados ao brain.
+
+Saída: lista de melhorias propostas. Nunca aplica destrutivamente sem confirmação.

--- a/lib/docs/DevelopingWithAI.mdx
+++ b/lib/docs/DevelopingWithAI.mdx
@@ -87,6 +87,30 @@ padding: 4px 6px — styles.scss:6
 
 Valores sem equivalente no token set são sinalizados com uma nota explicativa. O relatório fecha com um resumo do total de ocorrências encontradas.
 
+### `/create-pr`
+
+Cria um branch a partir da `main` e abre um pull request já com título em conventional commit, descrição estruturada e as labels do padrão da Consumidor Positivo (custo CapEx/OpEx, risco, prioridade, impacto e escopo). Também aplica as regras específicas de Aurora — atenção ao tipo do commit, que decide a versão publicada via release-please.
+
+**Como usar:**
+
+```
+/create-pr
+```
+
+Claude Code vai criar o branch, commitar o diff, abrir o PR e aplicar/criar as labels apropriadas. Antes de abrir, ele espelha o CI: roda `prebuild` (se mexeu em tokens/ícones), `lint` e os testes.
+
+**O que ele cuida por você:**
+
+- **Tipo do commit = versão.** `feat:` publica uma minor, `fix:`/`refactor:` uma patch, `docs:`/`chore:`/`test:` não publicam, e uma mudança incompatível (props, classes `au-`, tokens) é `feat!:`/`BREAKING CHANGE:` → major.
+- **Labels constitucionais** da org (consulta a skill `cp-capex` para o slug de custo).
+- **Nunca inclui arquivos gerados** (`lib/core/tokens/.cache/`, `lib/components/icons/`) no diff.
+
+---
+
+## Subagents e contexto de organização
+
+Além das skills, o repo traz subagents read-only em `.claude/agents/` (`code-reviewer` e `explorer`) e a documentação de negócio em `.ai-docs/` — lida por design/produto via o MCP `github-readonly` no Claude.ai. O `CLAUDE.md` raiz conecta o repo ao brain da Consumidor Positivo (org-skills `cp-*`) e descreve o protocolo de auto-melhoria que mantém esses docs vivos (ver `docs/self-improvement.md`).
+
 ---
 
 ## Adicionando novas skills


### PR DESCRIPTION
## Summary

Deixa o repositório Aurora "agent-ready" no padrão de IA da Consumidor Positivo (skill `cp-repo-setup`) e o conecta ao brain da org. Setup vivo: documentação por camadas (técnica / referência / negócio), subagents read-only e uma skill de PR com o baseline constitucional da empresa.

Como Aurora é um repo de **um serviço** (lib publicada), o `CLAUDE.md` raiz já era a camada técnica — foi **preservado** e apenas estendido; nada foi sobrescrito.

## Changes

- **`AGENTS.md`** → symlink para `CLAUDE.md` (compatibilidade com agentes que leem `AGENTS.md`).
- **`CLAUDE.md`** — novos blocos: *Releases & commits* (release-please), *Onde achar o resto*, *Contexto da organização* (conexão ao brain `cp-*`) e *Protocolo de auto-melhoria*.
- **`.ai-docs/`** — `README.md`, `services/aurora.md` (doc de negócio do design system, lido por design/produto via MCP `github-readonly`) e o eixo `missions/`.
- **`docs/`** — `self-improvement.md` (mantém os docs vivos) e `observability.md` (adaptado: Aurora é lib, sem runtime próprio → aponta para npm, Storybook, Chromatic, CI e app consumidor).
- **`.claude/agents/`** — subagents read-only `code-reviewer` e `explorer`.
- **`.claude/skills/create-pr/`** — skill `/create-pr`: baseline da org (CapEx/OpEx via `cp-capex`, risco, prioridade, impacto, escopo) + regras de Aurora (release-please, prebuild, lint, arquivos gerados).
- **`lib/docs/DevelopingWithAI.mdx`** — seção da `/create-pr` + bloco de subagents/contexto de IA.

## Breaking?

Não. Nenhuma mudança em código de componente, props, classes `au-` ou tokens públicos. Diff é 100% documentação + config de agentes. Commit tipado como `chore(ai)` → release-please **não** publica nova versão.

## Testing

Não aplicável a este diff: não há alteração em `lib/components`, tokens (`lib/core/tokens/*.json`), ícones (SVGs) ou build da lib — `prebuild`/`lint` (ts,tsx)/`test` não são afetados. O CI `aurora-tests.yml` roda mesmo assim no PR e deve passar verde.

## Pendências (não bloqueiam)

- `.ai-docs/services/aurora.md` é um starter — aprofundar com `/cp-ai-doc`.
- TODOs honestos em `docs/observability.md`: confirmar projeto Chromatic ativo e se o bucket/CloudFront do Storybook está em Terraform no `infrastructure`.
