### PR TITLE
feat: ✨: add AdBox component

### DIFF
--- a/lib/components/AdBox/AdBox.stories.tsx
+++ b/lib/components/AdBox/AdBox.stories.tsx
@@ -1,0 +1,81 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { AdBox, AdBoxProps } from '.'
+
+const meta: Meta<AdBoxProps> = {
+  title: 'Components/AdBox',
+  component: AdBox,
+  tags: ['autodocs'],
+  parameters: {
+    backgrounds: {
+      default: 'default',
+      values: [{ name: 'default', value: '#fff' }],
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof AdBox>
+
+const Placeholder = () => (
+  <span style={{ color: '#c4c9d4', fontSize: 14, fontWeight: 600 }}>
+    Placeholder
+  </span>
+)
+
+const Creative = () => (
+  <div
+    role="img"
+    aria-label="Anúncio do parceiro"
+    style={{
+      width: '100%',
+      height: 180,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      background: '#e2e4e9',
+      color: '#5e6573',
+      fontWeight: 600,
+    }}
+  >
+    Ad creative
+  </div>
+)
+
+const container = (args: AdBoxProps) => {
+  return (
+    <div style={{ width: 272 }}>
+      <AdBox {...args} />
+    </div>
+  )
+}
+
+// Desktop/mobile são automáticos via `@include aboveMedium()` — redimensione
+// o viewport para ver a variante Content alternar entre os dois layouts.
+export const Content: Story = {
+  render: (args) => container(args),
+  args: {
+    type: 'content',
+    children: <Placeholder />,
+  },
+}
+
+export const Heading: Story = {
+  render: (args) => (
+    <div style={{ width: 320 }}>
+      <AdBox {...args} />
+    </div>
+  ),
+  args: {
+    type: 'heading',
+    children: <Placeholder />,
+  },
+}
+
+export const WithCreative: Story = {
+  render: (args) => container(args),
+  args: {
+    type: 'content',
+    children: <Creative />,
+  },
+}

--- a/lib/components/AdBox/AdBox.test.tsx
+++ b/lib/components/AdBox/AdBox.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { AdBox } from '.'
+
+describe('AdBox', () => {
+  it('renders the mandatory "Publicidade" label and exposes it as aria-label', () => {
+    render(<AdBox />)
+
+    expect(screen.getByText('Publicidade')).toBeInTheDocument()
+    expect(
+      screen.getByRole('complementary', { name: 'Publicidade' }),
+    ).toBeInTheDocument()
+  })
+
+  it('applies the default type modifier (content)', () => {
+    render(<AdBox />)
+
+    const root = document.querySelector('.au-ad-box')
+    expect(root).toHaveClass('au-ad-box--type-content')
+  })
+
+  it('applies the given type modifier', () => {
+    render(<AdBox type="heading" />)
+
+    const root = document.querySelector('.au-ad-box')
+    expect(root).toHaveClass('au-ad-box--type-heading')
+  })
+
+  it('renders the creative passed as children in the slot', () => {
+    render(
+      <AdBox>
+        <img alt="Anúncio do parceiro" src="creative.png" />
+      </AdBox>,
+    )
+
+    expect(screen.getByAltText('Anúncio do parceiro')).toBeInTheDocument()
+  })
+
+  it('merges a custom className', () => {
+    render(<AdBox className="custom-class" />)
+
+    expect(document.querySelector('.au-ad-box')).toHaveClass('custom-class')
+  })
+})

--- a/lib/components/AdBox/index.tsx
+++ b/lib/components/AdBox/index.tsx
@@ -1,0 +1,32 @@
+import classNames from 'classnames'
+import './styles.scss'
+
+const AD_LABEL = 'Publicidade'
+
+export type AdBoxProps = {
+  children?: React.ReactNode
+  type?: 'content' | 'heading'
+  className?: string
+}
+
+export const AdBox = ({
+  children,
+  type = 'content',
+  className = '',
+}: AdBoxProps) => {
+  const classes = classNames('au-ad-box', {
+    [`au-ad-box--type-${type}`]: !!type,
+    [className]: !!className,
+  })
+
+  return (
+    <aside className={classes} aria-label={AD_LABEL}>
+      <div className="au-ad-box__heading">
+        <span className="au-ad-box__label">{AD_LABEL}</span>
+      </div>
+      <div className="au-ad-box__box">
+        <div className="au-ad-box__container">{children}</div>
+      </div>
+    </aside>
+  )
+}

--- a/lib/components/AdBox/styles.scss
+++ b/lib/components/AdBox/styles.scss
@@ -1,0 +1,66 @@
+.au-ad-box {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  font-family: $font-body;
+  background-color: $color-neutral-10;
+
+  &__heading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    padding: 4px 8px;
+  }
+
+  &__label {
+    color: $color-neutral-40;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 19px;
+    text-align: center;
+    text-transform: uppercase;
+    word-break: break-word;
+  }
+
+  &__box {
+    display: flex;
+    flex: 1 0 0;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    padding: 0 8px 8px;
+  }
+
+  &__container {
+    display: flex;
+    flex: 1 0 0;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    min-height: 64px;
+  }
+
+  // Content — mobile-first: bordered + squared, and the creative spans the
+  // full width (no side padding).
+  &--type-content &__box {
+    padding: 0 0 8px;
+  }
+
+  // Content — desktop (aboveMedium): rounded + clipped + borderless.
+  &--type-content {
+    @include aboveMedium() {
+      border: none;
+      border-radius: $border-radius-medium;
+      overflow: hidden;
+    }
+  }
+
+  // Content — desktop: side padding is restored around the creative.
+  &--type-content &__box {
+    @include aboveMedium() {
+      padding: 0 8px 8px;
+    }
+  }
+}

--- a/lib/components/Text/styles.scss
+++ b/lib/components/Text/styles.scss
@@ -56,7 +56,7 @@ $desk-variation: 'desk-';
 
   &--#{$viewport}heading-minimum {
     font-size: 18px;
-    line-height: 45px;
+    line-height: 24px;
   }
 
   &--#{$viewport}heading-micro {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -40,6 +40,7 @@ export { SubHeader } from './components/SubHeader'
 export { BadgeInfo } from './components/BadgeInfo'
 export { BadgeState } from './components/BadgeState'
 export { Divider } from './components/Divider'
+export { AdBox } from './components/AdBox'
 
 // Hooks
 export { useDrawer } from './components/Drawer/hooks'


### PR DESCRIPTION
## Summary

Adiciona o componente **`AdBox`** ao Aurora — um bloco de publicidade com o rótulo obrigatório "PUBLICIDADE" no topo e um slot (`children`) onde entra o criativo (imagem, iframe, banner). Baseado na spec do Figma (Aurora-DS, node `13111:8589`).

O rótulo é fixo por exigência de compliance (CONAR / Marco Civil da Internet) — não há prop para alterá-lo.

## Changes

- `lib/components/AdBox/index.tsx` — componente. Renderiza `<aside aria-label="Publicidade">` (`role="complementary"` implícito, como pede o Figma), rótulo não-focável e o slot para o criativo.
- `lib/components/AdBox/styles.scss` — estilos BEM `au-ad-box`. Desktop/mobile do tipo `content` são **automáticos** via `@include aboveMedium()` (não há prop `size`): mobile-first bordado + quadrado, sem padding lateral no criativo → desktop arredondado + `overflow:hidden` + borderless com padding lateral restaurado. Altura fluida (piso `min-height:64px` no slot).
- `lib/components/AdBox/AdBox.stories.tsx` — stories `Content`, `Heading`, `WithCreative`.
- `lib/components/AdBox/AdBox.test.tsx` — 5 testes (rótulo/aria, modifiers de `type`, slot de children, className).
- `lib/main.ts` — export do `AdBox`.

### API
```tsx
<AdBox type="content">{creative}</AdBox>   // type?: 'content' | 'heading' (default 'content')
```

## Breaking?

Não. Componente **novo**; não altera props, classes `au-` ou tokens existentes. `feat:` → release-please gera bump **minor** + publish.

## Testing

- `npx eslint lib/components/AdBox/ --max-warnings 0` → limpo (erros de lint no repo são pré-existentes, em outros componentes).
- `npm test` (AdBox) → 5/5 passando.
- `npm run build` → `dist/components/AdBox/` gerado; SCSS compilado, `@include aboveMedium()` → `@media (min-width:600px)`, tokens resolvidos.
- Sem `prebuild` (não toca em tokens/ícones).

<img width="404" height="893" alt="image" src="https://github.com/user-attachments/assets/bb413bb2-75fd-4d98-b524-28284423be69" />
