### PR TITLE
feat: ✨: add PartnerBanner component

### DIFF
--- a/lib/components/PartnerBanner/PartnerBanner.stories.tsx
+++ b/lib/components/PartnerBanner/PartnerBanner.stories.tsx
@@ -1,0 +1,40 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { IconGift } from '../icons/default'
+import { PartnerBanner, PartnerBannerProps } from '.'
+
+const meta: Meta<PartnerBannerProps> = {
+  title: 'Components/PartnerBanner',
+  component: PartnerBanner,
+  tags: ['autodocs'],
+  parameters: {
+    backgrounds: {
+      default: 'default',
+      values: [{ name: 'default', value: '#fff' }],
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof PartnerBanner>
+
+const container = (args: PartnerBannerProps) => {
+  return <PartnerBanner {...args} />
+}
+
+export const Default: Story = {
+  render: (args) => container(args),
+  args: {
+    text: 'Description text with more that two lines about something.',
+    btnText: 'Link Button',
+  },
+}
+
+export const WithIcon: Story = {
+  render: (args) => container(args),
+  args: {
+    text: 'Description text with more that two lines about something.',
+    btnText: 'Link Button',
+    icon: <IconGift />,
+  },
+}

--- a/lib/components/PartnerBanner/PartnerBanner.test.tsx
+++ b/lib/components/PartnerBanner/PartnerBanner.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { PartnerBanner } from '.'
+
+describe('PartnerBanner', () => {
+  it('renders the text and the button label', () => {
+    render(<PartnerBanner text="Oferta especial" btnText="Ver oferta" />)
+
+    expect(screen.getByText('Oferta especial')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Ver oferta' }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders as a complementary landmark labelled by ariaLabel', () => {
+    render(
+      <PartnerBanner
+        text="Oferta"
+        btnText="Ver"
+        ariaLabel="Oferta de parceiro"
+      />,
+    )
+
+    expect(
+      screen.getByRole('complementary', { name: 'Oferta de parceiro' }),
+    ).toBeInTheDocument()
+  })
+
+  it('exposes a button with type="button"', () => {
+    render(<PartnerBanner text="Oferta" btnText="Ver" />)
+
+    expect(screen.getByRole('button', { name: 'Ver' })).toHaveAttribute(
+      'type',
+      'button',
+    )
+  })
+
+  it('calls onButtonClick when the button is clicked', () => {
+    const onButtonClick = vi.fn()
+    render(
+      <PartnerBanner text="Oferta" btnText="Ver" onButtonClick={onButtonClick} />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ver' }))
+    expect(onButtonClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the icon and applies the --with-icon modifier when an icon is given', () => {
+    render(
+      <PartnerBanner
+        text="Oferta"
+        btnText="Ver"
+        icon={<svg data-testid="partner-icon" />}
+      />,
+    )
+
+    expect(screen.getByTestId('partner-icon')).toBeInTheDocument()
+    expect(document.querySelector('.au-partner-banner')).toHaveClass(
+      'au-partner-banner--with-icon',
+    )
+  })
+
+  it('does not render the icon slot nor the modifier when no icon is given', () => {
+    render(<PartnerBanner text="Oferta" btnText="Ver" />)
+
+    expect(document.querySelector('.au-partner-banner__icon')).toBeNull()
+    expect(document.querySelector('.au-partner-banner')).not.toHaveClass(
+      'au-partner-banner--with-icon',
+    )
+  })
+
+  it('merges a custom className', () => {
+    render(<PartnerBanner text="Oferta" btnText="Ver" className="custom-class" />)
+
+    expect(document.querySelector('.au-partner-banner')).toHaveClass(
+      'custom-class',
+    )
+  })
+})

--- a/lib/components/PartnerBanner/index.tsx
+++ b/lib/components/PartnerBanner/index.tsx
@@ -1,0 +1,54 @@
+import { ReactNode } from 'react'
+import classNames from 'classnames'
+import { Text } from '@components/Text'
+import './styles.scss'
+
+export type PartnerBannerProps = {
+  text: string
+  btnText: string
+  icon?: ReactNode
+  onButtonClick?: () => void
+  ariaLabel?: string
+  className?: string
+}
+
+export const PartnerBanner = ({
+  text,
+  btnText,
+  icon,
+  onButtonClick,
+  ariaLabel,
+  className = '',
+}: PartnerBannerProps) => {
+  const classes = classNames('au-partner-banner', {
+    [`au-partner-banner--with-icon`]: !!icon,
+    [className]: !!className,
+  })
+
+  return (
+    <aside className={classes} aria-label={ariaLabel}>
+      {icon && (
+        <div className="au-partner-banner__icon" aria-hidden="true">
+          {icon}
+        </div>
+      )}
+      <div className="au-partner-banner__content">
+        <Text
+          as="p"
+          variant="body-small"
+          color="secondary"
+          className="au-partner-banner__text">
+          {text}
+        </Text>
+        <button
+          type="button"
+          className="au-partner-banner__button"
+          onClick={onButtonClick}>
+          <Text as="span" variant="body-small" weight="semibold">
+            {btnText}
+          </Text>
+        </button>
+      </div>
+    </aside>
+  )
+}

--- a/lib/components/PartnerBanner/styles.scss
+++ b/lib/components/PartnerBanner/styles.scss
@@ -1,0 +1,50 @@
+.au-partner-banner {
+  display: flex;
+  gap: 16px;
+
+  border-radius: 16px;
+  background-color: $color-neutral-10;
+  padding: 16px;
+  width: 272px;
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+    gap: 8px;
+  }
+
+  &__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 32px;
+    width: 32px;
+    height: 32px;
+  }
+
+  &__text {
+    margin: 0;
+  }
+
+  &__button {
+    display: inline-flex;
+    align-items: center;
+    min-height: 24px;
+    border: none;
+    background: none;
+    border-radius: 4px;
+    cursor: pointer;
+
+    > span {
+      color: $color-brand-blue-40;
+    }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow:
+        0 0 0 2px $color-neutral-00,
+        0 0 0 4px $color-brand-blue-40;
+    }
+  }
+}

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -41,6 +41,7 @@ export { BadgeInfo } from './components/BadgeInfo'
 export { BadgeState } from './components/BadgeState'
 export { Divider } from './components/Divider'
 export { AdBox } from './components/AdBox'
+export { PartnerBanner, type PartnerBannerProps } from './components/PartnerBanner'
 
 // Hooks
 export { useDrawer } from './components/Drawer/hooks'


### PR DESCRIPTION
## Summary

Adiciona o componente **`PartnerBanner`** ao Aurora — um banner compacto de oferta de parceiro com ícone (opcional), texto descritivo e um CTA em estilo link. Composto sobre os componentes existentes `Button`/`Text` (reaproveitamento antes de criar).

Derivado do design no Figma ([node](https://www.figma.com/design/mJ6TJpnbZZYLiGXYnpg84b/Aurora-DS?node-id=18239-21746&m=dev)). Tipografia via `Text` (`body-small` / `secondary` = `#454A54`, o token exato do design).

## Changes

- `lib/components/PartnerBanner/index.tsx` — componente (named export, `type` para props, prefixo `au-`, BEM).
- `lib/components/PartnerBanner/styles.scss` — estilos escopados.
- `lib/components/PartnerBanner/PartnerBanner.stories.tsx` — stories `Default` e `WithIcon`.
- `lib/components/PartnerBanner/PartnerBanner.test.tsx` — testes unitários (render, landmark, `type=button`, click, estados de ícone, className).
- `lib/main.ts` — export de `PartnerBanner` + `PartnerBannerProps`.

### Props
| Prop | Tipo | Obrigatória |
|---|---|---|
| `text` | `string` | ✅ |
| `btnText` | `string` | ✅ |
| `icon` | `ReactNode` | — |
| `onButtonClick` | `() => void` | — |
| `ariaLabel` | `string` | — |
| `className` | `string` | — |

### Acessibilidade (WCAG 2.1 AA)
- Raiz `<aside>` (landmark complementar) + `aria-label` opcional via `ariaLabel`.
- CTA é `<button type="button">` (não dispara submit dentro de `<form>`), com nome acessível.
- `:focus-visible` com o anel padrão do DS (mesmo do `Chip`).
- Alvo de toque `min-height: 24px` (WCAG 2.5.8).
- Ícone `aria-hidden` (decorativo) e só renderiza quando presente.

## Breaking?

**Não.** Mudança puramente aditiva — novo componente + novo export. Nenhuma prop, classe `au-` ou token público existente foi alterado/removido. `feat:` → bump minor + publish (release-please).

## Testing

- `npm run lint` — arquivos do `PartnerBanner` limpos (os erros restantes são pré-existentes em `misc/Conditional`, `misc/Portal`, `icons/` — não tocados aqui).
- `npx vitest run` — suíte verde, incluindo **7 testes novos** do `PartnerBanner`.
- Typecheck (`tsc --noEmit`) sem erros no componente.

<img width="334" height="167" alt="image" src="https://github.com/user-attachments/assets/622fb99f-1478-4938-8f65-ab0d6de974a0" />
