### PR TITLE
feat: ✨: add Transition component

### DIFF
--- a/lib/components/Transition/Transition.stories.tsx
+++ b/lib/components/Transition/Transition.stories.tsx
@@ -1,0 +1,67 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { Transition, TransitionProps } from '.'
+
+const meta: Meta<TransitionProps> = {
+  title: 'Components/Transition',
+  component: Transition,
+  tags: ['autodocs'],
+  parameters: {
+    backgrounds: {
+      default: 'default',
+      values: [{ name: 'default', value: '#fff' }],
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Transition>
+
+const container = (args: TransitionProps) => {
+  return (
+    <div style={{ maxWidth: 480, margin: '0 auto', padding: 24 }}>
+      <Transition {...args} />
+    </div>
+  )
+}
+
+const messages = [
+  'Gerando acordo...',
+  'Ajustando detalhes do acordo...',
+  'Tudo pronto!',
+]
+
+export const Default: Story = {
+  render: (args) => container(args),
+  args: {
+    messages,
+    messageDuration: 2000,
+    align: 'left',
+  },
+}
+
+export const AlignCenter: Story = {
+  render: (args) => container(args),
+  args: {
+    messages,
+    messageDuration: 2000,
+    align: 'center',
+  },
+}
+
+export const AsyncGated: Story = {
+  render: (args) => container(args),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Enquanto `isLoading` for `true`, o fluxo segura na penúltima mensagem. Alterne para `false` nos controles para liberar a mensagem final ("Tudo pronto!") e disparar o `onFinish`.',
+      },
+    },
+  },
+  args: {
+    messages,
+    messageDuration: 2000,
+    isLoading: true,
+  },
+}

--- a/lib/components/Transition/Transition.test.tsx
+++ b/lib/components/Transition/Transition.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Transition } from './index'
+
+const messages = ['Gerando acordo...', 'Ajustando detalhes...', 'Tudo pronto!']
+
+describe('Transition', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const advance = (ms: number) => {
+    act(() => {
+      vi.advanceTimersByTime(ms)
+    })
+  }
+
+  it('starts on the first message with proportional progress', () => {
+    render(<Transition messages={messages} messageDuration={1000} />)
+
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-label', messages[0])
+    expect(bar).toHaveAttribute('aria-valuenow', '33')
+  })
+
+  it('advances through the messages on each step duration', () => {
+    render(<Transition messages={messages} messageDuration={1000} />)
+
+    advance(1000)
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-label',
+      messages[1],
+    )
+
+    advance(1000)
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-label', messages[2])
+    expect(bar).toHaveAttribute('aria-valuenow', '100')
+  })
+
+  it('calls onFinish after the last message', () => {
+    const onFinish = vi.fn()
+    render(
+      <Transition messages={messages} messageDuration={1000} onFinish={onFinish} />,
+    )
+
+    advance(1000) // -> step 1
+    advance(1000) // -> step 2 (last)
+    expect(onFinish).not.toHaveBeenCalled()
+
+    advance(1000) // last message shown for one duration
+    expect(onFinish).toHaveBeenCalledTimes(1)
+  })
+
+  it('holds on the penultimate message while isLoading is true', () => {
+    const onFinish = vi.fn()
+    const { rerender } = render(
+      <Transition
+        messages={messages}
+        messageDuration={1000}
+        isLoading
+        onFinish={onFinish}
+      />,
+    )
+
+    advance(1000) // -> penultimate (step 1)
+    advance(5000) // stays put while loading
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-label',
+      messages[1],
+    )
+    expect(onFinish).not.toHaveBeenCalled()
+
+    rerender(
+      <Transition
+        messages={messages}
+        messageDuration={1000}
+        isLoading={false}
+        onFinish={onFinish}
+      />,
+    )
+
+    advance(1000) // -> final message
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-label',
+      messages[2],
+    )
+
+    advance(1000)
+    expect(onFinish).toHaveBeenCalledTimes(1)
+  })
+})

--- a/lib/components/Transition/hooks.ts
+++ b/lib/components/Transition/hooks.ts
@@ -14,8 +14,6 @@ export const useTransition = ({
   onFinish,
 }: UseTransitionProps) => {
   const [currentStep, setCurrentStep] = useState(0)
-  // Paints the bar at 0 on the first frame so the fill animates from the
-  // start — CSS transitions don't run on the initial mount width.
   const [mounted, setMounted] = useState(false)
   const hasFinished = useRef(false)
   const onFinishRef = useRef(onFinish)
@@ -28,15 +26,12 @@ export const useTransition = ({
     setMounted(true)
   }, [])
 
-  // Restart the sequence when the flow is reconfigured.
   useEffect(() => {
     setCurrentStep(0)
     hasFinished.current = false
   }, [totalMessages, messageDuration])
 
   const isLast = currentStep >= totalMessages - 1
-  // When gated by `isLoading`, hold on the penultimate message until the real
-  // work resolves — the final message reads as a terminal success state.
   const holdIndex = Math.max(0, totalMessages - 2)
   const shouldHold = isLoading === true && currentStep >= holdIndex
 

--- a/lib/components/Transition/hooks.ts
+++ b/lib/components/Transition/hooks.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useState } from 'react'
+
+type UseTransitionProps = {
+  totalMessages: number
+  messageDuration: number
+  isLoading?: boolean
+  onFinish?: () => void
+}
+
+export const useTransition = ({
+  totalMessages,
+  messageDuration,
+  isLoading,
+  onFinish,
+}: UseTransitionProps) => {
+  const [currentStep, setCurrentStep] = useState(0)
+  // Paints the bar at 0 on the first frame so the fill animates from the
+  // start — CSS transitions don't run on the initial mount width.
+  const [mounted, setMounted] = useState(false)
+  const hasFinished = useRef(false)
+  const onFinishRef = useRef(onFinish)
+
+  useEffect(() => {
+    onFinishRef.current = onFinish
+  }, [onFinish])
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  // Restart the sequence when the flow is reconfigured.
+  useEffect(() => {
+    setCurrentStep(0)
+    hasFinished.current = false
+  }, [totalMessages, messageDuration])
+
+  const isLast = currentStep >= totalMessages - 1
+  // When gated by `isLoading`, hold on the penultimate message until the real
+  // work resolves — the final message reads as a terminal success state.
+  const holdIndex = Math.max(0, totalMessages - 2)
+  const shouldHold = isLoading === true && currentStep >= holdIndex
+
+  useEffect(() => {
+    if (isLast || shouldHold) return
+
+    const timer = setTimeout(() => {
+      setCurrentStep((step) => Math.min(step + 1, totalMessages - 1))
+    }, messageDuration)
+
+    return () => clearTimeout(timer)
+  }, [currentStep, shouldHold, isLast, messageDuration, totalMessages])
+
+  useEffect(() => {
+    if (!isLast || hasFinished.current) return
+    hasFinished.current = true
+
+    const timer = setTimeout(() => {
+      onFinishRef.current?.()
+    }, messageDuration)
+
+    return () => clearTimeout(timer)
+  }, [isLast, messageDuration])
+
+  const progress =
+    mounted && totalMessages > 0 ? ((currentStep + 1) / totalMessages) * 100 : 0
+
+  return { currentStep, progress }
+}

--- a/lib/components/Transition/index.tsx
+++ b/lib/components/Transition/index.tsx
@@ -6,19 +6,10 @@ import './styles.scss'
 export type TransitionAlign = 'left' | 'center'
 
 export type TransitionProps = {
-  /** Ordered loading messages — one per instance (design shows 3). */
   messages: string[]
-  /** Time each message is shown, in milliseconds. */
   messageDuration?: number
-  /** Horizontal alignment of the messages and progress bar. */
   align?: TransitionAlign
-  /**
-   * Optional async gate. While `true`, holds on the penultimate message;
-   * when it flips to `false`, advances to the final message and finishes.
-   * Omit it to run straight through all messages.
-   */
   isLoading?: boolean
-  /** Called once the last message has been shown. */
   onFinish?: () => void
   className?: string
 }

--- a/lib/components/Transition/index.tsx
+++ b/lib/components/Transition/index.tsx
@@ -1,0 +1,93 @@
+import classNames from 'classnames'
+import { Text } from '@components/Text'
+import { useTransition } from './hooks'
+import './styles.scss'
+
+export type TransitionAlign = 'left' | 'center'
+
+export type TransitionProps = {
+  /** Ordered loading messages — one per instance (design shows 3). */
+  messages: string[]
+  /** Time each message is shown, in milliseconds. */
+  messageDuration?: number
+  /** Horizontal alignment of the messages and progress bar. */
+  align?: TransitionAlign
+  /**
+   * Optional async gate. While `true`, holds on the penultimate message;
+   * when it flips to `false`, advances to the final message and finishes.
+   * Omit it to run straight through all messages.
+   */
+  isLoading?: boolean
+  /** Called once the last message has been shown. */
+  onFinish?: () => void
+  className?: string
+}
+
+export const Transition = ({
+  messages,
+  messageDuration = 2000,
+  align = 'left',
+  isLoading,
+  onFinish,
+  className,
+}: TransitionProps) => {
+  const { currentStep, progress } = useTransition({
+    totalMessages: messages.length,
+    messageDuration,
+    isLoading,
+    onFinish,
+  })
+
+  const currentMessage = messages[currentStep] ?? ''
+  const previousMessage = currentStep > 0 ? messages[currentStep - 1] : null
+
+  return (
+    <div
+      className={classNames(
+        'au-transition',
+        `au-transition--align-${align}`,
+        className,
+      )}>
+      <div className="au-transition__messages">
+        <Text
+          as="p"
+          variant="heading-medium"
+          weight="semibold"
+          aria-hidden="true"
+          className={classNames(
+            'au-transition__message',
+            'au-transition__message--previous',
+            { 'au-transition__message--hidden': !previousMessage },
+          )}>
+          {previousMessage || ' '}
+        </Text>
+
+        <Text
+          key={currentStep}
+          as="p"
+          variant="heading-medium"
+          weight="semibold"
+          aria-live="polite"
+          className="au-transition__message au-transition__message--current">
+          {currentMessage}
+        </Text>
+      </div>
+
+      <div
+        className="au-transition__bar"
+        role="progressbar"
+        aria-valuenow={Math.round(progress)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={currentMessage}>
+        <div
+          className="au-transition__bar-filled"
+          style={{
+            width: `${progress}%`,
+            transitionDuration: `${messageDuration}ms`,
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/lib/components/Transition/styles.scss
+++ b/lib/components/Transition/styles.scss
@@ -1,0 +1,80 @@
+.au-transition {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  width: 100%;
+
+  &--align-left {
+    align-items: flex-start;
+    text-align: start;
+  }
+
+  &--align-center {
+    align-items: center;
+    text-align: center;
+  }
+
+  &__messages {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
+  }
+
+  &__message {
+    transition: opacity 0.3s ease;
+  }
+
+  &__message--previous.au-text {
+    color: $color-neutral-10;
+  }
+
+  &__message--hidden {
+    opacity: 0;
+  }
+
+  &__message--current {
+    animation: au-transition-fade-in 0.5s ease;
+  }
+
+  &__bar {
+    background-color: $color-neutral-20;
+    border-radius: 4px;
+    overflow: hidden;
+    width: 100%;
+    height: 8px;
+
+    @include aboveLarge() {
+      width: 416px;
+    }
+  }
+
+  &__bar-filled {
+    background-color: $color-brand-blue-40;
+    border-radius: 500px;
+    height: 100%;
+    transition-property: width;
+    transition-timing-function: linear;
+  }
+
+  @keyframes au-transition-fade-in {
+    from {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .au-transition__message--current {
+      animation: none;
+    }
+
+    .au-transition__bar-filled {
+      transition: none;
+    }
+  }
+}

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -43,6 +43,7 @@ export { Divider } from './components/Divider'
 export { AdBox } from './components/AdBox'
 export { ChipBanner } from './components/ChipBanner'
 export { PartnerBanner, type PartnerBannerProps } from './components/PartnerBanner'
+export { Transition, type TransitionProps } from './components/Transition'
 
 // Hooks
 export { useDrawer } from './components/Drawer/hooks'


### PR DESCRIPTION
## Summary

Adiciona o componente **`Transition`** ao Aurora — uma barra de progresso animada com mensagens sequenciais, pensada como padrão para telas de transição em fluxos (ex.: geração/ajuste de acordo). O componente entrega **apenas a barra + as mensagens**; a tela em si fica a cargo do app consumidor.

Baseado no design do Figma ([node 18137-13133](https://www.figma.com/design/mJ6TJpnbZZYLiGXYnpg84b/Aurora-DS?node-id=18137-13133)) e inspirado no `Loader` do MatchMaker (CreditKit).

## Changes

- `lib/components/Transition/index.tsx` — componente + tipos públicos (`TransitionProps`, `TransitionAlign`)
- `lib/components/Transition/hooks.ts` — `useTransition`: avanço automático das mensagens, gate assíncrono opcional e animação da barra a partir do 0
- `lib/components/Transition/styles.scss` — layout responsivo, tokens do DS, `prefers-reduced-motion`
- `lib/components/Transition/Transition.stories.tsx` — stories (Default, AlignCenter, Fast, AsyncGated com descrição na doc)
- `lib/components/Transition/Transition.test.tsx` — 4 testes (avanço, progresso, `onFinish`, gate `isLoading`)
- `lib/main.ts` — export do componente + tipo

### API

```tsx
<Transition
  messages={['Gerando acordo...', 'Ajustando detalhes do acordo...', 'Tudo pronto!']}
  messageDuration={2000}   // opcional (default 2000ms)
  align="left"             // 'left' (default) | 'center'
  isLoading={loading}      // opcional — gate assíncrono
  onFinish={() => navigate('/proximo')}
/>
```

- **Autoplay** por padrão; `isLoading` opcional segura na penúltima mensagem enquanto o trabalho real acontece e libera a final ("Tudo pronto!") + `onFinish` quando resolve.
- Reusa **tokens** do DS (`$color-brand-blue-40`, `$color-neutral-20`, `$color-neutral-10`) em vez de valores hardcoded.
- A11y: `role="progressbar"` + `aria-valuenow/min/max`, `aria-live` na mensagem, `prefers-reduced-motion`.

## Breaking?

**Não.** Mudança puramente aditiva — novo componente e novo export, sem alterar props, classes `au-` ou tokens existentes. `feat:` → bump minor + publish (release-please).

## Testing

- `npx vitest run lib/components/Transition/Transition.test.tsx` → 4/4 passando
- Lint e typecheck limpos nos arquivos novos
- Sem mudança em tokens/ícones → `prebuild` não necessário

<img width="1028" height="924" alt="image" src="https://github.com/user-attachments/assets/db389bb6-211c-4e00-a508-5dcd1183afcd" />
