### PR TITLE
feat(tabs)!: unify variants and add keyboard/ARIA accessibility

### DIFF
--- a/lib/components/Tabs/Tabs.stories.tsx
+++ b/lib/components/Tabs/Tabs.stories.tsx
@@ -1,10 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
 import { TabsProps } from '.'
 import { Tabs } from '.'
-import { LogoBadgetAC } from '@components/Logo'
-import { LogoBadgetCP } from '@components/Logo'
-import { LogoPrimaryNegativeAC } from '@components/Logo'
-import { IconCheckCircle } from '@components/icons'
 
 const meta: Meta<TabsProps> = {
   title: 'Components/Tabs',
@@ -22,69 +18,51 @@ export default meta
 
 type Story = StoryObj<TabsProps>
 
-export const CustomContent: Story = {
+export const Default: Story = {
   args: {
     tabs: [
       {
-        title: 'Logo do AC',
-        tab: 'tab 1',
-        icon: <IconCheckCircle />,
-        children: <LogoBadgetAC />,
-      },
-      {
-        title: 'Logo do CP',
-        tab: 'tab 2',
-        children: <LogoBadgetCP />,
-      },
-      {
-        title: 'Logo do AC Negativo',
-        tab: 'tab 3',
-        children: <LogoPrimaryNegativeAC />,
-      },
-    ],
-    initialTab: 'tab 1',
-    onClick: () => {
-      console.log('tab clicked')
-    },
-  },
-}
-
-export const WithLabel: Story = {
-  args: {
-    tabs: [
-      {
-        title: 'Todos',
-        tab: 'all',
+        title: 'Dívidas',
+        tab: 'debts',
         children: (
-          <div style={{ padding: '20px' }}>
-            <h3>Todos os Itens</h3>
-            <p>Visualize todos os itens disponíveis no sistema.</p>
+          <div>
+            <h3>Dívidas</h3>
+            <p>Visualize todas as dívidas encontradas no seu CPF.</p>
           </div>
         ),
       },
       {
-        title: 'Ativos',
-        tab: 'active',
+        title: 'Acordos',
+        tab: 'agreements',
         children: (
-          <div style={{ padding: '20px' }}>
-            <h3>Itens Ativos</h3>
-            <p>Lista apenas os itens que estão atualmente ativos.</p>
+          <div>
+            <h3>Acordos</h3>
+            <p>Acompanhe os acordos em andamento.</p>
           </div>
         ),
       },
       {
-        title: 'Inativos',
-        tab: 'inactive',
+        title: 'Contas',
+        tab: 'bills',
         children: (
-          <div style={{ padding: '20px' }}>
-            <h3>Itens Inativos</h3>
-            <p>Visualize os itens que foram desativados.</p>
+          <div>
+            <h3>Contas</h3>
+            <p>Veja suas contas cadastradas.</p>
+          </div>
+        ),
+      },
+      {
+        title: 'Score',
+        tab: 'score',
+        children: (
+          <div>
+            <h3>Score</h3>
+            <p>Consulte a evolução do seu score.</p>
           </div>
         ),
       },
     ],
-    initialTab: 'all',
-    withLabel: true,
+    initialTab: 'debts',
     onClick: (tab) => {
       console.log('Tab clicada:', tab)
     },
@@ -98,7 +76,7 @@ export const WithRightSlot: Story = {
         title: 'Dashboard',
         tab: 'dashboard',
         children: (
-          <div style={{ padding: '20px' }}>
+          <div>
             <h3>Dashboard Principal</h3>
             <p>Visão geral dos dados e métricas importantes.</p>
           </div>
@@ -108,161 +86,30 @@ export const WithRightSlot: Story = {
         title: 'Vendas',
         tab: 'sales',
         children: (
-          <div style={{ padding: '20px' }}>
+          <div>
             <h3>Relatório de Vendas</h3>
             <p>Acompanhe o desempenho das vendas em tempo real.</p>
-          </div>
-        ),
-      },
-      {
-        title: 'Clientes',
-        tab: 'customers',
-        children: (
-          <div style={{ padding: '20px' }}>
-            <h3>Gestão de Clientes</h3>
-            <p>Visualize e gerencie informações dos clientes.</p>
           </div>
         ),
       },
     ],
     initialTab: 'dashboard',
     rightSlotChildren: (
-      <div
+      <button
         style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: '8px',
+          padding: '6px 12px',
+          backgroundColor: '#007bff',
+          color: 'white',
+          border: 'none',
+          borderRadius: '4px',
+          fontSize: '12px',
+          cursor: 'pointer',
         }}>
-        <button
-          style={{
-            padding: '6px 12px',
-            backgroundColor: '#007bff',
-            color: 'white',
-            border: 'none',
-            borderRadius: '4px',
-            fontSize: '12px',
-            cursor: 'pointer',
-          }}>
-          + Novo
-        </button>
-        <button
-          style={{
-            padding: '6px 8px',
-            backgroundColor: '#6c757d',
-            color: 'white',
-            border: 'none',
-            borderRadius: '4px',
-            fontSize: '12px',
-            cursor: 'pointer',
-          }}>
-          ⚙️
-        </button>
-      </div>
+        + Novo
+      </button>
     ),
     onClick: (tab) => {
       console.log('Tab clicada:', tab)
-    },
-  },
-}
-
-export const WithLabelAndRightSlot: Story = {
-  args: {
-    tabs: [
-      {
-        title: 'Projetos',
-        tab: 'projects',
-        children: (
-          <div style={{ padding: '20px' }}>
-            <h3>Meus Projetos</h3>
-            <p>Lista de todos os projetos ativos e em desenvolvimento.</p>
-          </div>
-        ),
-      },
-      {
-        title: 'Arquivados',
-        tab: 'archived',
-        children: (
-          <div style={{ padding: '20px' }}>
-            <h3>Projetos Arquivados</h3>
-            <p>Visualize projetos que foram arquivados.</p>
-          </div>
-        ),
-      },
-      {
-        title: 'Favoritos',
-        tab: 'favorites',
-        children: (
-          <div style={{ padding: '20px' }}>
-            <h3>Projetos Favoritos</h3>
-            <p>Seus projetos marcados como favoritos.</p>
-          </div>
-        ),
-      },
-    ],
-    initialTab: 'projects',
-    withLabel: true,
-    rightSlotChildren: (
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: '8px',
-        }}>
-        <button
-          style={{
-            padding: '6px 12px',
-            backgroundColor: '#007bff',
-            color: 'white',
-            border: 'none',
-            borderRadius: '4px',
-            fontSize: '12px',
-            cursor: 'pointer',
-          }}>
-          + Novo Projeto
-        </button>
-        <button
-          style={{
-            padding: '4px 8px',
-            backgroundColor: 'transparent',
-            border: '1px solid #dee2e6',
-            borderRadius: '4px',
-            fontSize: '12px',
-            cursor: 'pointer',
-          }}>
-          ⚙️ Configurações
-        </button>
-      </div>
-    ),
-    onClick: (tab) => {
-      console.log('Tab clicada:', tab)
-    },
-  },
-}
-
-export const TwoType: Story = {
-  args: {
-    tabs: [
-      {
-        title: 'Logo do AC',
-        tab: 'tab 1',
-        icon: <IconCheckCircle />,
-        children: <LogoBadgetAC />,
-      },
-      {
-        title: 'Logo do CP',
-        tab: 'tab 2',
-        children: <LogoBadgetCP />,
-      },
-      {
-        title: 'Logo do AC Negativo',
-        tab: 'tab 3',
-        children: <LogoPrimaryNegativeAC />,
-      },
-    ],
-    type: 2,
-    initialTab: 'tab 1',
-    onClick: () => {
-      console.log('tab clicked')
     },
   },
 }

--- a/lib/components/Tabs/Tabs.test.tsx
+++ b/lib/components/Tabs/Tabs.test.tsx
@@ -12,8 +12,8 @@ describe('Tabs', () => {
   it('renders tab buttons and children', () => {
     render(<Tabs tabs={tabs} />)
 
-    expect(screen.getByText('One')).toBeInTheDocument()
-    expect(screen.getByText('Two')).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'One' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Two' })).toBeInTheDocument()
 
     // by default no initial is selected, children are present but wrapped
     expect(document.querySelector('.children-one')).toBeTruthy()
@@ -24,8 +24,11 @@ describe('Tabs', () => {
     render(<Tabs tabs={tabs} initialTab="one" />)
     expect(screen.getByText('one content')).toBeInTheDocument()
 
-    const activeChip = document.querySelector('.au-chip--active')
-    expect(activeChip).toBeTruthy()
+    const activeTab = screen.getByRole('tab', { name: 'One' })
+    expect(activeTab.classList.contains('au-tabs__btns-option--active')).toBe(
+      true,
+    )
+    expect(activeTab).toHaveAttribute('aria-selected', 'true')
   })
 
   it('hides tabs panel when areTabsHidden is true', () => {
@@ -34,27 +37,56 @@ describe('Tabs', () => {
     expect(document.querySelector('.children-one')).toBeTruthy()
   })
 
-  it('calls onClick and activates tab on chip click', async () => {
+  it('calls onClick and activates tab on click', async () => {
     const onClick = vi.fn()
     render(<Tabs tabs={tabs} onClick={onClick} />)
 
     const user = userEvent.setup()
-    const twoBtn = screen.getByText('Two')
+    const twoBtn = screen.getByRole('tab', { name: 'Two' })
     await user.click(twoBtn)
 
     expect(onClick).toHaveBeenCalledWith('two')
-    const activeChip = document.querySelector('.au-chip--active')
-    expect(activeChip).toBeTruthy()
+    expect(twoBtn.classList.contains('au-tabs__btns-option--active')).toBe(true)
+    expect(twoBtn).toHaveAttribute('aria-selected', 'true')
     expect(screen.getByText('two content')).toBeInTheDocument()
   })
 
-  it('shows label when withLabel is true', () => {
-    render(<Tabs tabs={tabs} withLabel />)
-    expect(screen.getByText(/Filtrar por/i)).toBeInTheDocument()
+  it('links tabs and panels with ARIA roles and attributes', () => {
+    render(<Tabs tabs={tabs} initialTab="one" />)
+
+    expect(screen.getByRole('tablist')).toBeInTheDocument()
+
+    const tabOne = screen.getByRole('tab', { name: 'One' })
+    expect(tabOne).toHaveAttribute('aria-controls', 'au-tabpanel-one')
+
+    const panelOne = document.getElementById('au-tabpanel-one')
+    expect(panelOne).toHaveAttribute('role', 'tabpanel')
+    expect(panelOne).toHaveAttribute('aria-labelledby', 'au-tab-one')
   })
 
-  it('renders type 2 layout and applies active class correctly', async () => {
-    render(<Tabs tabs={tabs} type={2} initialTab="one" />)
+  it('moves focus between tabs with arrow, Home and End keys', async () => {
+    render(<Tabs tabs={tabs} initialTab="one" />)
+
+    const user = userEvent.setup()
+    const tabOne = screen.getByRole('tab', { name: 'One' })
+    const tabTwo = screen.getByRole('tab', { name: 'Two' })
+
+    tabOne.focus()
+    await user.keyboard('{ArrowRight}')
+    expect(tabTwo).toHaveFocus()
+
+    await user.keyboard('{ArrowRight}')
+    expect(tabOne).toHaveFocus()
+
+    await user.keyboard('{End}')
+    expect(tabTwo).toHaveFocus()
+
+    await user.keyboard('{Home}')
+    expect(tabOne).toHaveFocus()
+  })
+
+  it('renders the animated indicator and applies active class correctly', async () => {
+    render(<Tabs tabs={tabs} initialTab="one" />)
 
     const activeTab = document.querySelector('.au-tabs__btns-option--active')
     expect(activeTab).toBeTruthy()
@@ -72,7 +104,7 @@ describe('Tabs', () => {
     )
   })
 
-  it('calculates indicator position on type 2', () => {
+  it('calculates the indicator position from the active tab', () => {
     Object.defineProperty(HTMLElement.prototype, 'offsetLeft', {
       configurable: true,
       value: 100,
@@ -82,7 +114,7 @@ describe('Tabs', () => {
       value: 50,
     })
 
-    render(<Tabs tabs={tabs} type={2} initialTab="one" />)
+    render(<Tabs tabs={tabs} initialTab="one" />)
 
     const indicator = document.querySelector(
       '.au-tabs__btns-indicator',

--- a/lib/components/Tabs/index.tsx
+++ b/lib/components/Tabs/index.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useState, useRef } from 'react'
-import { If, Switch, Case } from '@components/misc'
-import { Text } from '@components/Text'
-import { Chip } from '@components/Chip'
+import { If } from '@components/misc'
 
 import classNames from 'classnames'
 
@@ -9,10 +7,8 @@ import './styles.scss'
 
 export type TabsProps = {
   tabs: TabItemProps[]
-  type?: 1 | 2
   areTabsHidden?: boolean
   initialTab?: string
-  withLabel?: boolean
   rightSlotChildren?: React.ReactNode
   onClick?: (value: string) => void
   'data-testid'?: string
@@ -22,21 +18,16 @@ export type TabItemProps = {
   tab: string
   title: string
   children?: React.ReactElement
-  icon?: React.ReactNode
 }
 
 export const Tabs = ({
   tabs,
-  type = 1,
   initialTab,
   onClick,
   areTabsHidden,
   rightSlotChildren,
-  withLabel = false,
   'data-testid': dataTestId,
 }: TabsProps) => {
-  const [isClicked, setIsClicked] = useState(false)
-  const [currButton, setCurrButton] = useState(initialTab ?? '')
   const [activeTab, setActiveTab] = useState(initialTab)
   const [indicatorStyle, setIndicatorStyle] = useState({ left: 0, width: 0 })
 
@@ -47,88 +38,89 @@ export const Tabs = ({
   }, [initialTab])
 
   useEffect(() => {
-    if (activeTab && type === 2) {
-      const container = tabsRef.current
-      if (container) {
-        const activeElement = container.querySelector(
-          '.au-tabs__btns-option--active',
-        ) as HTMLElement
+    const container = tabsRef.current
+    if (activeTab && container) {
+      const activeElement = container.querySelector(
+        '.au-tabs__btns-option--active',
+      ) as HTMLElement
 
-        if (activeElement) {
-          setIndicatorStyle({
-            left: activeElement.offsetLeft,
-            width: activeElement.offsetWidth,
-          })
-        }
+      if (activeElement) {
+        setIndicatorStyle({
+          left: activeElement.offsetLeft,
+          width: activeElement.offsetWidth,
+        })
       }
     }
-  }, [activeTab, tabs, type])
+  }, [activeTab, tabs])
 
   const handleClick = (item: TabItemProps) => {
     onClick && onClick(item.tab)
-    setCurrButton(item.tab)
     setActiveTab(item.tab)
-    setIsClicked(true)
   }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return
+
+    const container = tabsRef.current
+    if (!container) return
+
+    const tabButtons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[role="tab"]'),
+    )
+    const currentIndex = tabButtons.indexOf(
+      document.activeElement as HTMLButtonElement,
+    )
+    if (currentIndex === -1) return
+
+    event.preventDefault()
+
+    const lastIndex = tabButtons.length - 1
+    const nextIndex = {
+      ArrowLeft: currentIndex === 0 ? lastIndex : currentIndex - 1,
+      ArrowRight: currentIndex === lastIndex ? 0 : currentIndex + 1,
+      Home: 0,
+      End: lastIndex,
+    }[event.key as 'ArrowLeft' | 'ArrowRight' | 'Home' | 'End']
+
+    tabButtons[nextIndex]?.focus()
+  }
+
+  const focusableTab = activeTab ?? tabs[0]?.tab
 
   return (
     <>
       <If condition={!areTabsHidden}>
-        <div
-          className={classNames('au-tabs', {
-            [`au-tabs--type-${type}`]: !!type,
-          })}
-          data-testid={dataTestId}>
+        <div className="au-tabs" data-testid={dataTestId}>
           <div className="au-tabs__container">
-            <div className="au-tabs__left-panel">
-              <If condition={!!withLabel}>
-                <Text
-                  color="secondary"
-                  variant="body-small"
-                  className="au-tabs__label">
-                  Filtrar por:{' '}
-                </Text>
-              </If>
-              <div className="au-tabs__btns" ref={tabsRef}>
-                {tabs.map((item: TabItemProps) => {
-                  return (
-                    <Switch key={item.tab}>
-                      <Case condition={type === 1}>
-                        <Chip
-                          label={item.title}
-                          icon={item.icon}
-                          isActive={
-                            (isClicked && item.tab === currButton) ||
-                            activeTab === item.tab
-                          }
-                          onClick={() => handleClick(item)}
-                        />
-                      </Case>
-                      <Case condition={type === 2}>
-                        <button
-                          type="button"
-                          className={classNames('au-tabs__btns-option', {
-                            'au-tabs__btns-option--active':
-                              activeTab === item.tab,
-                          })}
-                          onClick={() => handleClick(item)}>
-                          {item.title}
-                        </button>
-                      </Case>
-                    </Switch>
-                  )
-                })}
-                <If condition={type === 2}>
-                  <div
-                    className="au-tabs__btns-indicator"
-                    aria-hidden="true"
-                    style={{
-                      left: `${indicatorStyle.left}px`,
-                      width: `${indicatorStyle.width}px`,
-                    }}
-                  />
-                </If>
-              </div>
+            <div
+              className="au-tabs__btns"
+              role="tablist"
+              ref={tabsRef}
+              onKeyDown={handleKeyDown}>
+              {tabs.map((item: TabItemProps) => (
+                <button
+                  key={item.tab}
+                  type="button"
+                  role="tab"
+                  id={`au-tab-${item.tab}`}
+                  aria-selected={activeTab === item.tab}
+                  aria-controls={`au-tabpanel-${item.tab}`}
+                  tabIndex={item.tab === focusableTab ? 0 : -1}
+                  className={classNames('au-tabs__btns-option', {
+                    'au-tabs__btns-option--active': activeTab === item.tab,
+                  })}
+                  onClick={() => handleClick(item)}>
+                  {item.title}
+                </button>
+              ))}
+              <div
+                className="au-tabs__btns-indicator"
+                aria-hidden="true"
+                style={{
+                  left: `${indicatorStyle.left}px`,
+                  width: `${indicatorStyle.width}px`,
+                }}
+              />
             </div>
             <If condition={!!rightSlotChildren}>{rightSlotChildren}</If>
           </div>
@@ -138,11 +130,12 @@ export const Tabs = ({
       {tabs.map(({ children, tab }: TabItemProps) => {
         return (
           <div
+            role="tabpanel"
+            id={`au-tabpanel-${tab}`}
+            aria-labelledby={`au-tab-${tab}`}
             className={`au-tabs__children children-${tab}`}
             key={`au-tabs-${tab}`}>
-            <If condition={currButton === tab || activeTab === tab}>
-              {children}
-            </If>
+            <If condition={activeTab === tab}>{children}</If>
           </div>
         )
       })}

--- a/lib/components/Tabs/styles.scss
+++ b/lib/components/Tabs/styles.scss
@@ -1,16 +1,5 @@
 .au-tabs {
-  &--type-2 {
-    border-bottom: 1px solid $color-neutral-20;
-
-    button {
-      border: 0;
-      background-color: transparent;
-    }
-
-    .au-tabs__btns {
-      margin-bottom: 0;
-    }
-  }
+  border-bottom: 1px solid $color-neutral-20;
 
   &__container {
     display: flex;
@@ -23,27 +12,12 @@
     }
   }
 
-  &__left-panel {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-
-  &__label {
-    display: none;
-
-    @include aboveMedium() {
-      display: unset;
-    }
-  }
-
   &__btns {
     display: flex;
     position: relative;
     white-space: nowrap;
-    overflow-x: scroll;
+    overflow-x: auto;
     overflow-y: hidden;
-    margin-bottom: 20px;
 
     &::-webkit-scrollbar {
       display: none;
@@ -51,27 +25,33 @@
 
     @include aboveMedium() {
       overflow: unset;
-      margin-bottom: 0;
     }
 
     &-option {
+      display: flex;
+      flex: 1 0 0;
+      align-items: center;
+      justify-content: center;
+      min-height: 36px;
       border: none;
       background: none;
-      font: inherit;
-      color: inherit;
-      text-align: inherit;
       cursor: pointer;
-      line-height: 20px;
-      color: $color-neutral-50;
-      font-size: $font-size-p3;
+      padding: $spacing-100 $spacing-300;
       font-family: $font-title;
-      padding: $spacing-100 $spacing-200;
+      font-size: $font-size-p3;
+      font-weight: $font-weight-regular;
+      line-height: 1.4;
+      color: $color-neutral-50;
       position: relative;
       transition: all 0.3s ease;
 
+      @include aboveMedium() {
+        flex: 0 0 auto;
+      }
+
       &--active {
         color: $color-brand-blue-40;
-        font-weight: $font-weight-bold;
+        font-weight: $font-weight-semibold;
       }
     }
 


### PR DESCRIPTION
## Summary

Unifica o componente **Tabs** em um único layout (o antigo `type={2}`, com indicador animado sublinhado) e adiciona acessibilidade completa: semântica ARIA de tabs e navegação por teclado.

## Changes

- **Variante única**: removida a variante `type={1}` (baseada em `Chip`) e as props `type`, `withLabel` (label "Filtrar por:") e `icon` — o layout sublinhado passa a ser o único.
- **ARIA**: `role="tablist"` no container, `role="tab"` com `aria-selected`/`aria-controls` nos botões e `role="tabpanel"` com `aria-labelledby` nos painéis, com IDs vinculados (`au-tab-<tab>` ↔ `au-tabpanel-<tab>`).
- **Teclado**: roving tabindex + navegação com `ArrowLeft`/`ArrowRight` (circular), `Home` e `End`.
- **Estado interno simplificado**: removidos `isClicked`/`currButton` redundantes; só `activeTab` controla seleção.
- **Estilos**: tabs ocupam largura igual no mobile (`flex: 1`) e largura de conteúdo acima do breakpoint médio; `overflow-x: scroll` → `auto`; peso da fonte ativa `bold` → `semibold`.
- **Testes**: cobertura nova para ARIA e navegação por teclado (261 testes passando no total).
- **Stories**: simplificadas para a variante única.

## Breaking?

**Sim — major.**
- Props removidas: `TabsProps.type`, `TabsProps.withLabel`, `TabItemProps.icon`.
- Classes `au-` removidas: `au-tabs--type-1`, `au-tabs--type-2`, `au-tabs__left-panel`, `au-tabs__label`.
- Consumidores que usavam `type={1}` (chips) precisam migrar para o layout único ou compor com `Chip` diretamente.

## Testing

- `npm test` — 45 arquivos, 261 testes ✅
- `npm run build` — ✅
- `npm run lint` — sem erros nos arquivos alterados (os 6 erros existentes são pré-existentes em `misc/Conditional`, `Text/types.ts`, `Datepicker.test` e `Carousel.test`, fora deste diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
