### PR TITLE
feat(modal): add opt-in closeOnBackdropClick and document off-Figma props

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,12 @@ Tests use Vitest with jsdom and `@testing-library/react`. Setup is in `vitest.se
 
 Versioning and `CHANGELOG.md` are automated by **release-please** (`.github/workflows/release.yml`) from the conventional commits merged into `main`. The commit/PR title type drives the bump: `feat:` → minor + npm publish, `fix:`/`refactor:` → patch + publish, `docs:`/`chore:`/`test:` → changelog only (no publish), breaking change (`feat!:` or `BREAKING CHANGE:`) → major. Since Aurora is consumed by external apps, changing public props, `au-` classes, or exported tokens is a **breaking change** — type the commit accordingly. The `/create-pr` skill encodes this.
 
+## Gotchas & tech debt
+
+- `Button` prop `negative` é no-op: aplica a classe `au-btn--negative` ([lib/components/Button/index.tsx:86](lib/components/Button/index.tsx)) mas **não existe SCSS para ela** — o visual "Negative" do Figma (botões brancos para fundos coloridos) nunca foi implementado. Não exponha story até implementar.
+- `BadgeInfo` prop `actionButton` é declarada no type ([lib/components/BadgeInfo/index.tsx:21](lib/components/BadgeInfo/index.tsx)) mas nunca é renderizada pelo componente. Marcada `@deprecated`; remover no próximo major.
+- `Checkbox.Field` não tem prop de posição do controle (`Radio.Field` tem `direction: 'left' | 'right'`); o Figma prevê `Position: Left | Right` para ambos.
+
 ## Onde achar o resto (ponteiros)
 
 - **Referência longa & operação:** `docs/` — `docs/self-improvement.md` (protocolo que mantém os docs vivos) e `docs/observability.md` (onde investigar quando um componente quebra — Aurora é lib, não tem runtime próprio).

--- a/lib/components/BadgeInfo/index.tsx
+++ b/lib/components/BadgeInfo/index.tsx
@@ -17,6 +17,7 @@ export type BadgeInfoProps = {
   text: string
   children?: React.ReactNode
   customIcon?: string | JSX.Element
+  /** @deprecated Declared but never rendered by the component — passing it has no effect. */
   actionButton?: { content?: string; onClick?: () => void }
   'data-testid'?: string
 }

--- a/lib/components/Button/index.tsx
+++ b/lib/components/Button/index.tsx
@@ -19,16 +19,22 @@ type ButtonProps = (
   children?: ReactNode | string | JSX.Element | JSX.Element[]
   color?: 'default'
   disabled?: boolean
+  /** Stretches the button to fill the container width. Not mapped in Figma. */
   expand?: 'x'
   htmlType?: 'button' | 'submit' | 'reset'
   loading?: boolean
   size?: 'large' | 'medium'
+  /** Visual type. 'link' maps to the "Link Button" component in Figma (which also has a Small size not available here). */
   type?: 'primary' | 'outlined' | 'ghost' | 'link'
   target?: string
+  /** Inverted colors for colored backgrounds (Figma: Negative). No-op today: `au-btn--negative` has no styles yet. */
   negative?: boolean
+  /** Renders as a plain text button (class `btn-text`). Not mapped in Figma. */
   btnText?: boolean
+  /** Icon-only round button (Figma: Style=Icon). */
   round?: boolean
   className?: string
+  /** Border width modifier (`au-btn--border-*`). Not mapped in Figma. */
   borderWidth?: string
   elementRef?: React.RefObject<HTMLButtonElement | HTMLAnchorElement>
 }

--- a/lib/components/Modal/Modal.stories.tsx
+++ b/lib/components/Modal/Modal.stories.tsx
@@ -58,6 +58,33 @@ export const Default: Story = {
   },
 }
 
+export const CloseOnBackdropClick: Story = {
+  render: (args) => {
+    return (
+      <div style={{ minHeight: '400px' }}>
+        <Modal {...args} />
+      </div>
+    )
+  },
+  args: {
+    isOpen: true,
+    onClose: () => console.log('Modal closed'),
+    closeOnBackdropClick: true,
+    headerContent: (
+      <Text variant="heading-small" weight="bold">
+        Close on backdrop click
+      </Text>
+    ),
+    content: (
+      <div style={{ margin: '16px 0' }}>
+        Clicking outside the container calls <code>onClose</code>. Opt-in via
+        the <code>closeOnBackdropClick</code> prop — default behavior is
+        unchanged.
+      </div>
+    ),
+  },
+}
+
 export const Centralized: Story = {
   render: (args) => {
     return (

--- a/lib/components/Modal/Modal.test.tsx
+++ b/lib/components/Modal/Modal.test.tsx
@@ -83,4 +83,38 @@ describe('Modal', () => {
 
     expect(modal).toHaveClass('au-modal--mobile-full-screen')
   })
+
+  it('calls onClose when backdrop is clicked and closeOnBackdropClick is true', async () => {
+    const onClose = vi.fn()
+    const { container } = renderModal({ onClose, closeOnBackdropClick: true })
+
+    const user = userEvent.setup()
+    await user.click(container.querySelector('.au-modal') as HTMLElement)
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call onClose when backdrop is clicked and closeOnBackdropClick is not set', async () => {
+    const onClose = vi.fn()
+    const { container } = renderModal({ onClose })
+
+    const user = userEvent.setup()
+    await user.click(container.querySelector('.au-modal') as HTMLElement)
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not call onClose when clicking inside the container with closeOnBackdropClick', async () => {
+    const onClose = vi.fn()
+    renderModal({
+      onClose,
+      closeOnBackdropClick: true,
+      content: 'Inner Content',
+    })
+
+    const user = userEvent.setup()
+    await user.click(screen.getByText('Inner Content'))
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
 })

--- a/lib/components/Modal/index.tsx
+++ b/lib/components/Modal/index.tsx
@@ -13,6 +13,8 @@ type ModalLayoutMobile = 'default' | 'centralized' | 'full-screen'
 export type ModalProps = {
   isOpen: boolean
   onClose?: () => void
+  /** Calls onClose when the backdrop (area outside the container) is clicked */
+  closeOnBackdropClick?: boolean
   headerContent?: React.ReactNode | string | JSX.Element | JSX.Element[]
   content?: React.ReactNode | string | JSX.Element | JSX.Element[]
   layoutMobile?: ModalLayoutMobile
@@ -26,6 +28,7 @@ export type ModalProps = {
 export const Modal = ({
   isOpen,
   onClose,
+  closeOnBackdropClick = false,
   headerContent,
   content,
   layoutMobile = 'default',
@@ -44,12 +47,19 @@ export const Modal = ({
     'au-modal--desktop-centralized': layoutDesktop === 'centralized',
   })
 
+  function handleBackdropClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (closeOnBackdropClick && e.target === e.currentTarget && onClose) {
+      onClose()
+    }
+  }
+
   return (
     <div
       className={modalClasses}
       role="dialog"
       aria-modal="true"
       aria-label={ariaLabel ?? mobileModalTitle}
+      onClick={handleBackdropClick}
       data-testid={dataTestId}>
       <div className="au-modal__container">
         <div className="au-modal__header">

--- a/lib/components/Tabs/index.tsx
+++ b/lib/components/Tabs/index.tsx
@@ -7,8 +7,10 @@ import './styles.scss'
 
 export type TabsProps = {
   tabs: TabItemProps[]
+  /** Hides the tab bar and renders only the active panel. Not mapped in Figma. */
   areTabsHidden?: boolean
   initialTab?: string
+  /** Content rendered at the right side of the tab bar. Not mapped in Figma. */
   rightSlotChildren?: React.ReactNode
   onClick?: (value: string) => void
   'data-testid'?: string

--- a/lib/components/form/SelectField/types.ts
+++ b/lib/components/form/SelectField/types.ts
@@ -20,6 +20,7 @@ export type SelectFieldProps = React.HTMLAttributes<HTMLDivElement> & {
   register?: (instance: HTMLSelectElement | null) => void
   autocomplete?: boolean
   EmptyText?: string
+  /** On mobile, opens the options list in a full-screen modal. Not mapped in Figma. */
   fullScreenOptions?: boolean
   htmlType?: 'text' | 'number'
   'data-testid'?: string

--- a/lib/components/form/TextareaField/index.tsx
+++ b/lib/components/form/TextareaField/index.tsx
@@ -10,6 +10,7 @@ export type TextAreaProps =
     label?: string
     textAreaStyle?: React.CSSProperties
     textareaRef?: React.RefObject<HTMLTextAreaElement>
+    /** Allows the user to resize the textarea horizontally. Not mapped in Figma. */
     horizontalResize?: boolean
   }
 


### PR DESCRIPTION
## Summary

Onda 0 do plano de convergência **Figma × Código** (auditoria v2, jul/2026): quick wins sem breaking change — fecha o gap crítico do backdrop do Modal e torna visível (Storybook autodocs + IDE) o comportamento das props que existem no código mas não no Figma.

## Changes

- **Modal**: nova prop opt-in `closeOnBackdropClick` — clicar no backdrop (fora do container) chama o `onClose`. Default `false`, comportamento atual inalterado. Cobertura de teste (backdrop fecha / sem a prop não fecha / clique no conteúdo não fecha) + story `CloseOnBackdropClick`.
- **JSDoc nas props sem correspondência no Figma** (aparecem na tabela de props do Storybook e no hover do IDE): `Button.expand/btnText/borderWidth/type`, `SelectField.fullScreenOptions`, `TextAreaField.horizontalResize`, `Tabs.areTabsHidden/rightSlotChildren`.
- **`BadgeInfo.actionButton` marcada `@deprecated`**: a prop é declarada no type mas nunca renderizada pelo componente — passar ela não tem efeito. A anotação risca a prop no autocomplete dos consumidores sem quebrar compilação; remoção fica para o próximo major.
- **`Button.negative` documentada como no-op**: a classe `au-btn--negative` é aplicada mas **não existe SCSS para ela** — a auditoria de maio dizia que o estilo existia; não existe. A story continua comentada de propósito (exibi-la mostraria um botão idêntico ao primary). Implementar o visual Negative do Figma (botões brancos p/ fundos coloridos, por type × estado) foi movido para a Onda 1.
- **CLAUDE.md**: gotchas registrados (negative no-op, actionButton morto, `Checkbox.Field` sem a prop `direction` que o `Radio.Field` tem e o Figma prevê).

### Verificações feitas nesta onda (sem mudança de código)

- `chip-order` do Figma → coberto por `Chip variant='order'` ✓
- Date Picker Month/Year dropdowns → existem no `CalendarHeader` ✓
- Radio `direction: left|right` ✓ · Checkbox não tem (gap menor, backlog)

## Breaking?

Não. Só adições (prop opt-in com default `false`, comentários JSDoc, anotação `@deprecated`). Nenhuma prop, classe `au-` ou token alterado/removido.

## Testing

- `npx vitest run lib/components/Modal/Modal.test.tsx` → 10/10 ✓ (3 novos)
- `npm test` (suíte completa) → 264/264 ✓
- `npx eslint` nos arquivos tocados → limpo (os erros do `npm run lint` são pré-existentes na main, em `misc/Conditional` e `misc/Portal`; o CI `aurora-tests.yml` roda apenas testes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
