### PR TITLE
feat(special-button): add slide-to-action animation (Figma spec)

### DIFF
--- a/lib/components/SpecialButton/SpecialButton.test.tsx
+++ b/lib/components/SpecialButton/SpecialButton.test.tsx
@@ -138,6 +138,14 @@ function _mockContainerWidth(container: HTMLElement, width: number) {
 }
 
 describe('SpecialButton type="slider"', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('renders the label and the knob', () => {
     const { getByText, getByRole } = render(
       <SpecialButton type="slider">Slide to action</SpecialButton>,
@@ -162,13 +170,41 @@ describe('SpecialButton type="slider"', () => {
     fireEvent.pointerMove(knob, { clientX: 250 })
     fireEvent.pointerUp(knob)
 
+    act(() => {
+      vi.advanceTimersByTime(400)
+    })
+
     expect(onConfirm).toHaveBeenCalledTimes(1)
     expect(root.className).toContain('au-special-button--success')
   })
 
-  it('snaps back without confirming when released early', () => {
+  it('completes by itself once the knob passes 70% of the track', () => {
     const onConfirm = vi.fn()
     const { container, getByRole } = render(
+      <SpecialButton type="slider" onConfirm={onConfirm}>
+        Slide to action
+      </SpecialButton>,
+    )
+    // track width 272 → max drag 224 → 70% threshold at 156.8
+    const root = _mockContainerWidth(container, 272)
+    const knob = getByRole('button')
+
+    fireEvent.pointerDown(knob, { clientX: 0 })
+    fireEvent.pointerMove(knob, { clientX: 160 })
+
+    expect(root.className).toContain('au-special-button--completing')
+
+    act(() => {
+      vi.advanceTimersByTime(400)
+    })
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    expect(root.className).toContain('au-special-button--success')
+  })
+
+  it('snaps back and shows the hint when released early', () => {
+    const onConfirm = vi.fn()
+    const { container, getByRole, getByText } = render(
       <SpecialButton type="slider" onConfirm={onConfirm}>
         Slide to action
       </SpecialButton>,
@@ -180,8 +216,31 @@ describe('SpecialButton type="slider"', () => {
     fireEvent.pointerMove(knob, { clientX: 50 })
     fireEvent.pointerUp(knob)
 
+    act(() => {
+      vi.advanceTimersByTime(400)
+    })
+
     expect(onConfirm).not.toHaveBeenCalled()
     expect(root.className).not.toContain('au-special-button--success')
+    expect(
+      getByText('Arraste até o final para confirmar ação'),
+    ).toBeInTheDocument()
+  })
+
+  it('supports a custom incomplete hint', () => {
+    const { container, getByRole, getByText } = render(
+      <SpecialButton type="slider" incompleteHint="Continue arrastando">
+        Slide to action
+      </SpecialButton>,
+    )
+    _mockContainerWidth(container, 272)
+    const knob = getByRole('button')
+
+    fireEvent.pointerDown(knob, { clientX: 0 })
+    fireEvent.pointerMove(knob, { clientX: 50 })
+    fireEvent.pointerUp(knob)
+
+    expect(getByText('Continue arrastando')).toBeInTheDocument()
   })
 
   it('confirms via keyboard on the focused knob', () => {

--- a/lib/components/SpecialButton/index.tsx
+++ b/lib/components/SpecialButton/index.tsx
@@ -11,7 +11,10 @@ import './styles.scss'
 
 const KNOB_SIZE = 40
 const TRACK_PADDING = 4
-const CONFIRM_THRESHOLD = 0.85
+// Figma (Behavior): a partir de ~70% do trajeto a ação já conta como
+// confirmada e o botão se completa sozinho.
+const CONFIRM_THRESHOLD = 0.7
+const COMPLETE_ANIMATION_MS = 400
 
 export type SpecialButtonProps = {
   /**
@@ -47,6 +50,12 @@ export type SpecialButtonProps = {
    * swipe gesture).
    */
   knobAriaLabel?: string
+  /**
+   * Slider only — helper text shown below the button after an incomplete
+   * drag, guiding the user to slide all the way to the end.
+   * @default 'Arraste até o final para confirmar ação'
+   */
+  incompleteHint?: ReactNode
   'data-testid'?: string
 }
 
@@ -146,16 +155,23 @@ const _SliderButton = ({
   success = false,
   skeleton = false,
   knobAriaLabel = 'Arraste para confirmar',
+  incompleteHint = 'Arraste até o final para confirmar ação',
   'data-testid': dataTestId,
 }: SpecialButtonProps) => {
   const containerRef = useRef<HTMLDivElement>(null)
   const startXRef = useRef(0)
+  const completeTimerRef = useRef<number>()
   const [dragging, setDragging] = useState(false)
   const [dragX, setDragX] = useState(0)
+  const [completing, setCompleting] = useState(false)
+  const [showHint, setShowHint] = useState(false)
   const [confirmed, setConfirmed] = useState(false)
 
   const isSuccess = success || confirmed
-  const isInteractive = !disabled && !loading && !isSuccess && !skeleton
+  const isInteractive =
+    !disabled && !loading && !isSuccess && !skeleton && !completing
+
+  useEffect(() => () => window.clearTimeout(completeTimerRef.current), [])
 
   function _maxDrag() {
     const container = containerRef.current
@@ -168,6 +184,18 @@ const _SliderButton = ({
     if (onConfirm) onConfirm()
   }
 
+  function _complete() {
+    setDragging(false)
+    setCompleting(true)
+    setShowHint(false)
+    setDragX(_maxDrag())
+    completeTimerRef.current = window.setTimeout(() => {
+      setCompleting(false)
+      setDragX(0)
+      _confirm()
+    }, COMPLETE_ANIMATION_MS)
+  }
+
   function handlePointerDown(event: React.PointerEvent<HTMLButtonElement>) {
     if (!isInteractive) return
     setDragging(true)
@@ -177,15 +205,17 @@ const _SliderButton = ({
 
   function handlePointerMove(event: React.PointerEvent<HTMLButtonElement>) {
     if (!dragging) return
+    const max = _maxDrag()
     const delta = event.clientX - startXRef.current
-    setDragX(Math.min(Math.max(delta, 0), _maxDrag()))
+    const next = Math.min(Math.max(delta, 0), max)
+    setDragX(next)
+    if (max > 0 && next >= max * CONFIRM_THRESHOLD) _complete()
   }
 
   function handlePointerEnd() {
     if (!dragging) return
     setDragging(false)
-    const max = _maxDrag()
-    if (max > 0 && dragX >= max * CONFIRM_THRESHOLD) _confirm()
+    if (dragX > 0) setShowHint(true)
     setDragX(0)
   }
 
@@ -203,6 +233,7 @@ const _SliderButton = ({
     {
       [`au-special-button--variant-${variant}`]: !!variant,
       'au-special-button--dragging': dragging,
+      'au-special-button--completing': completing,
       'au-special-button--disabled': disabled,
       'au-special-button--loading': loading,
       'au-special-button--success': isSuccess,
@@ -216,28 +247,46 @@ const _SliderButton = ({
     return <IconArrowRight aria-hidden="true" />
   }
 
+  const maxDrag = _maxDrag()
+  const dragProgress = maxDrag > 0 ? dragX / maxDrag : 0
+
   return (
-    <div ref={containerRef} className={classes} data-testid={dataTestId}>
-      {loading && <IconLoader />}
-      {!loading && !skeleton && (
-        <>
-          <span className="au-special-button__label">{children}</span>
-          <button
-            type="button"
-            className="au-special-button__knob"
-            aria-label={knobAriaLabel}
-            disabled={disabled}
-            style={
-              dragX > 0 ? { transform: `translateX(${dragX}px)` } : undefined
-            }
-            onPointerDown={handlePointerDown}
-            onPointerMove={handlePointerMove}
-            onPointerUp={handlePointerEnd}
-            onPointerCancel={handlePointerEnd}
-            onKeyDown={handleKeyDown}>
-            {_renderKnobIcon()}
-          </button>
-        </>
+    <div className="au-special-button-wrapper">
+      <div
+        ref={containerRef}
+        className={classes}
+        style={
+          {
+            '--au-special-button-progress': dragProgress,
+          } as React.CSSProperties
+        }
+        data-testid={dataTestId}>
+        {loading && <IconLoader />}
+        {!loading && !skeleton && (
+          <>
+            <span className="au-special-button__label">{children}</span>
+            <button
+              type="button"
+              className="au-special-button__knob"
+              aria-label={knobAriaLabel}
+              disabled={disabled}
+              style={
+                dragX > 0 ? { transform: `translateX(${dragX}px)` } : undefined
+              }
+              onPointerDown={handlePointerDown}
+              onPointerMove={handlePointerMove}
+              onPointerUp={handlePointerEnd}
+              onPointerCancel={handlePointerEnd}
+              onKeyDown={handleKeyDown}>
+              {_renderKnobIcon()}
+            </button>
+          </>
+        )}
+      </div>
+      {showHint && !isSuccess && (
+        <span className="au-special-button__hint" role="status">
+          {incompleteHint}
+        </span>
       )}
     </div>
   )

--- a/lib/components/SpecialButton/styles.scss
+++ b/lib/components/SpecialButton/styles.scss
@@ -122,8 +122,16 @@
     transition: none;
   }
 
+  // ação confirmada (≥70% do trajeto): o knob completa o percurso sozinho
+  &--completing &__knob {
+    cursor: default;
+    transition: transform 0.4s ease-out;
+  }
+
   &--type-slider &__label {
     padding: 8px 48px;
+    opacity: calc(1 - var(--au-special-button-progress, 0) * 1.4);
+    transition: opacity 0.1s linear;
   }
 
   &--variant-secondary {
@@ -153,6 +161,11 @@
     background-color: $color-success-40;
     border: none;
     color: $color-neutral-00;
+  }
+
+  // Figma: o success do slider mostra só o check, sem label
+  &--type-slider.au-special-button--success &__label {
+    opacity: 0;
   }
 
   &--type-slider.au-special-button--success &__knob {
@@ -201,6 +214,20 @@
     border: none;
     animation: au-special-button-pulse 1.5s ease-in-out infinite;
   }
+
+  &__hint {
+    display: block;
+    margin-top: 8px;
+    text-align: center;
+    font-family: $font-body;
+    font-size: 12px;
+    font-weight: 400;
+    color: $color-neutral-60;
+  }
+}
+
+.au-special-button-wrapper {
+  width: 100%;
 }
 
 @keyframes au-special-button-spin {


### PR DESCRIPTION
## Summary

Adds the slide-to-action animation to `SpecialButton type="slider"`, aligning the component with the **Behavior** section of the Figma spec (Swipe Button). Continuation of the Figma×Code convergence work (#280, #283, #285).

## Changes

- **Auto-complete at 70%**: once the knob passes ~70% of the track (even without releasing), the action counts as confirmed and the knob animates the rest of the way by itself (`--completing` state, 0.4s ease-out) before entering success. Previously the component only confirmed on release, at 85%.
- **Incomplete-drag hint**: releasing before the threshold snaps the knob back (animated) and shows a helper text below the button — *"Arraste até o final para confirmar ação"* — with `role="status"` for screen readers. Customizable via the new `incompleteHint` prop.
- **Gradual label fade**: the label fades progressively as the knob slides over it (CSS var `--au-special-button-progress`), matching the "suave e gradativa" transition described in the spec.
- **Success without label**: the slider success state now hides the label (opacity 0), showing only the check — as in Figma.

## Breaking?

No breaking change to props, `au-` classes or tokens — only additions. One structural note: the slider is now wrapped in `div.au-special-button-wrapper` so the hint can render below the track (which has `overflow: hidden`). The `au-special-button` class and `data-testid` stay on the same element; apps styling the slider via direct-child selectors on its parent may need a look.

Behavior change by design: confirm threshold moved from 85% (release-only) to 70% (auto-complete), per the Figma spec.

## Testing

- `npm test` — 18/18 SpecialButton tests passing, including 3 new ones: auto-complete past 70%, hint on incomplete release, custom `incompleteHint`.
- `npm run build` — library builds clean.
- CI-equivalent (`prebuild` + `test:coverage`) unaffected; no generated files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Mission: convergencia-figma-codigo
