### PR TITLE
chore(claude): habilita o plugin cp-eng neste repo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "enabledPlugins": {
+    "cp-eng@consumidor-positivo": true
+  },
   "hooks": {
     "PostToolUse": [
       {


### PR DESCRIPTION
As convenções de **como se constrói** software (`cp-frontend`, `cp-backend`, `cp-aws`, `cp-redline-event`, `cp-capex`) saíram do `cp-brain` e viraram o plugin **`cp-eng`**, em [claude-org-context#110](https://github.com/AcordoCertoBR/claude-org-context/pull/110).

Elas eram fleet-wide: a empresa inteira pagava 4.459 chars de contexto por sessão por convenções que só quem abre um repo de código usa. Agora quem liga é **o repo**, porque `enabledPlugins` tem escopo *any file*.

**Sem este bloco, quem trabalha neste repo perde essas cinco skills** — e a skill `create-pr` não acha a régua de CapEx/OpEx.

É uma chave em `.claude/settings.json` (versionado, vale para todo mundo que clona). Nada mais muda: hooks, permissions e o resto do arquivo ficam intactos. Efeito no próximo cold start do Claude Code.

Gerado em lote pela Plataforma/AI. Dúvida: Lucas Rodrigues.